### PR TITLE
Fix unused imports refactor so it doesn't lose inner types.

### DIFF
--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/imports/UnusedImportRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/imports/UnusedImportRefactor.java
@@ -30,6 +30,8 @@ import org.eclipse.text.edits.MalformedTreeException;
  * Removes unused imports.
  *
  * This refactor can be run standalone, but will also be run as part of cleanup after any operation has altered a file.
+ *
+ * This refactor currently loses comments that are on the import lines e.g. // NOPMD.
  */
 public class UnusedImportRefactor implements ASTOperation {
 
@@ -73,7 +75,7 @@ public class UnusedImportRefactor implements ASTOperation {
           }
 
           // remove non-static imports from java.lang - they don't need to be imported
-          if (! importDeclaration.isStatic() && importDeclaration.getName().toString().startsWith("java.lang")
+          if (! importDeclaration.isStatic() && importDeclaration.getName().toString().split("java\\.lang\\.[A-Z]").length > 1
               && !AstraUtils.isImportOfInnerType(importDeclaration)) {
             AstraUtils.removeImport(compilationUnit, importDeclaration, rewriter);
             continue;

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/imports/UnusedImportRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/imports/UnusedImportRefactor.java
@@ -58,6 +58,11 @@ public class UnusedImportRefactor implements ASTOperation {
             existingImports.add(importDeclaration.getName().toString());
           }
 
+          // Can't easily tell if on-demand imports are actually needed so best to leave them in place.
+          if (importDeclaration.isOnDemand()) {
+            continue;
+          }
+
           // remove unused imports
           // TODO this doesn't properly handle static imports yet - they are quite problematic as you can't accurately resolve the method signature
           // (can be multiple methods with same name)

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/utils/AstraUtils.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/utils/AstraUtils.java
@@ -177,7 +177,7 @@ public class AstraUtils {
   public static String getFullyQualifiedName(Type type) {
     Optional<ITypeBinding> typeBinding = Optional.ofNullable(type)
         .map(Type::resolveBinding);
-    
+
     if (typeBinding
         .filter(tb -> tb.isRecovered())
         .isPresent()) {
@@ -242,6 +242,14 @@ public class AstraUtils {
   }
 
 
+  /**
+   * @return true if the import is for an inner type e.g. import com.Foo.Bar
+   */
+  public static boolean isImportOfInnerType(ImportDeclaration importDeclaration) {
+    return !importDeclaration.isOnDemand() && importDeclaration.getName().isQualifiedName();
+  }
+
+
   public static ITypeBinding resolveGenericTypeArgumentsForSimpleName(SimpleName variableName) {
     IBinding resolveBinding = variableName.resolveBinding();
     if (resolveBinding instanceof IVariableBinding) {
@@ -299,8 +307,8 @@ public class AstraUtils {
     final ListRewrite modifiersList = rewriter.getListRewrite(nodeToAnnotate, modifiersProperty);
     modifiersList.insertFirst(annotation, null);
   }
-  
-  
+
+
   /**
    * Builds an annotation with a single 'value' content.
    *
@@ -333,12 +341,12 @@ public class AstraUtils {
    * @param rewriter AST re-writer to apply changes.
    */
   public static void addImport(CompilationUnit compilationUnit, String importPath, ASTRewrite rewriter) {
-    
+
     // If the type to import is a parameterized type, only import the base type
     if (importPath.contains("<")) {
       importPath = importPath.substring(0, importPath.indexOf("<"));
     }
-    
+
     addImport(compilationUnit, importPath, rewriter, false);
   }
 
@@ -363,7 +371,7 @@ public class AstraUtils {
       // We'd likely get here due to missing classpaths
       return;
     }
-    
+
     final ListRewrite importList = rewriter.getListRewrite(compilationUnit, CompilationUnit.IMPORTS_PROPERTY);
     @SuppressWarnings("unchecked")
     List<ImportDeclaration> currentList = importList.getRewrittenList();

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/utils/AstraUtils.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/utils/AstraUtils.java
@@ -246,7 +246,7 @@ public class AstraUtils {
    * @return true if the import is for an inner type e.g. import com.Foo.Bar
    */
   public static boolean isImportOfInnerType(ImportDeclaration importDeclaration) {
-    return !importDeclaration.isOnDemand() && importDeclaration.getName().isQualifiedName();
+    return !importDeclaration.isOnDemand() && importDeclaration.getName().toString().split("\\.[A-Z]").length > 2;
   }
 
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/ExampleTypeSamePackage.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/ExampleTypeSamePackage.java
@@ -1,0 +1,9 @@
+package org.alfasoftware.astra.core.refactoring.imports;
+
+public class ExampleTypeSamePackage {
+
+  static class OtherInnerClass {
+
+  }
+}
+

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExample.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExample.java
@@ -1,15 +1,19 @@
 package org.alfasoftware.astra.core.refactoring.imports;
 
 import static org.alfasoftware.astra.exampleTypes.A.STRING_VALUE_A;
-import static org.alfasoftware.astra.exampleTypes.C.STRING_VALUE_C;
+import static org.alfasoftware.astra.exampleTypes.C.STRING_VALUE_C; // not referenced
+import static org.alfasoftware.astra.exampleTypes.C.staticTwo;
+import static org.alfasoftware.astra.exampleTypes.D.staticOne; // not referenced
 
+import java.lang.Math; // not needed - directly in java.lang
 import java.lang.Thread.State;
+import java.lang.reflect.Method;
 
-import org.alfasoftware.astra.core.refactoring.imports.ExampleTypeSamePackage;
+import org.alfasoftware.astra.core.refactoring.imports.ExampleTypeSamePackage; // not needed same package, but not inner type
 import org.alfasoftware.astra.core.refactoring.imports.ExampleTypeSamePackage.OtherInnerClass;
 import org.alfasoftware.astra.core.refactoring.imports.UnusedImportExample.InnerClassExample;
 import org.alfasoftware.astra.exampleTypes.A;
-import org.alfasoftware.astra.exampleTypes.B;
+import org.alfasoftware.astra.exampleTypes.B; // not referenced
 import org.alfasoftware.astra.exampleTypes.C;
 import org.alfasoftware.astra.exampleTypes.D;
 import org.junit.experimental.categories.Category;
@@ -21,12 +25,16 @@ public class UnusedImportExample {
   A a = new A();
   OtherInnerClass inner = new OtherInnerClass();
   State baseState = State.RUNNABLE;
+  Method methodRef;
 
   /**
    * {@link C}
    * {@link D#one()}
    */
   private String foo() {
+    staticTwo();
+    ExampleTypeSamePackage example = new ExampleTypeSamePackage();
+    int r = Math.abs(-12);
     return STRING_VALUE_A;
   }
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExample.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExample.java
@@ -1,9 +1,13 @@
 package org.alfasoftware.astra.core.refactoring.imports;
 
 import static org.alfasoftware.astra.exampleTypes.A.STRING_VALUE_A;
+import static org.alfasoftware.astra.exampleTypes.C.STRING_VALUE_C;
 
+import org.alfasoftware.astra.core.refactoring.imports.ExampleTypeSamePackage;
+import org.alfasoftware.astra.core.refactoring.imports.ExampleTypeSamePackage.OtherInnerClass;
 import org.alfasoftware.astra.core.refactoring.imports.UnusedImportExample.InnerClassExample;
 import org.alfasoftware.astra.exampleTypes.A;
+import org.alfasoftware.astra.exampleTypes.B;
 import org.alfasoftware.astra.exampleTypes.C;
 import org.alfasoftware.astra.exampleTypes.D;
 import org.junit.experimental.categories.Category;
@@ -13,6 +17,8 @@ import org.junit.experimental.categories.Category;
 public class UnusedImportExample {
 
   A a = new A();
+  OtherInnerClass inner = new OtherInnerClass();
+
   /**
    * {@link C}
    * {@link D#one()}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExample.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExample.java
@@ -5,6 +5,7 @@ import static org.alfasoftware.astra.exampleTypes.C.STRING_VALUE_C; // not refer
 import static org.alfasoftware.astra.exampleTypes.C.staticTwo;
 import static org.alfasoftware.astra.exampleTypes.D.staticOne; // not referenced
 
+
 import java.lang.Math; // not needed - directly in java.lang
 import java.lang.Thread.State;
 import java.lang.reflect.Method;
@@ -16,6 +17,7 @@ import org.alfasoftware.astra.exampleTypes.A;
 import org.alfasoftware.astra.exampleTypes.B; // not referenced
 import org.alfasoftware.astra.exampleTypes.C;
 import org.alfasoftware.astra.exampleTypes.D;
+import org.junit.*; 
 import org.junit.experimental.categories.Category;
 
 @SuppressWarnings("unused")
@@ -35,6 +37,7 @@ public class UnusedImportExample {
     staticTwo();
     ExampleTypeSamePackage example = new ExampleTypeSamePackage();
     int r = Math.abs(-12);
+    Assert.assertEquals(12, r);
     return STRING_VALUE_A;
   }
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExample.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExample.java
@@ -3,6 +3,8 @@ package org.alfasoftware.astra.core.refactoring.imports;
 import static org.alfasoftware.astra.exampleTypes.A.STRING_VALUE_A;
 import static org.alfasoftware.astra.exampleTypes.C.STRING_VALUE_C;
 
+import java.lang.Thread.State;
+
 import org.alfasoftware.astra.core.refactoring.imports.ExampleTypeSamePackage;
 import org.alfasoftware.astra.core.refactoring.imports.ExampleTypeSamePackage.OtherInnerClass;
 import org.alfasoftware.astra.core.refactoring.imports.UnusedImportExample.InnerClassExample;
@@ -18,6 +20,7 @@ public class UnusedImportExample {
 
   A a = new A();
   OtherInnerClass inner = new OtherInnerClass();
+  State baseState = State.RUNNABLE;
 
   /**
    * {@link C}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExample.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExample.java
@@ -1,11 +1,15 @@
 package org.alfasoftware.astra.core.refactoring.imports;
 
+import static org.alfasoftware.astra.exampleTypes.A.STRING_VALUE_A;
+
+import org.alfasoftware.astra.core.refactoring.imports.UnusedImportExample.InnerClassExample;
 import org.alfasoftware.astra.exampleTypes.A;
-import org.alfasoftware.astra.exampleTypes.B;
 import org.alfasoftware.astra.exampleTypes.C;
 import org.alfasoftware.astra.exampleTypes.D;
+import org.junit.experimental.categories.Category;
 
 @SuppressWarnings("unused")
+@Category(InnerClassExample.class)
 public class UnusedImportExample {
 
   A a = new A();
@@ -13,7 +17,12 @@ public class UnusedImportExample {
    * {@link C}
    * {@link D#one()}
    */
-  private void foo() {
+  private String foo() {
+    return STRING_VALUE_A;
+  }
+
+  static class InnerClassExample {
+
   }
 }
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExampleAfter.java
@@ -2,6 +2,7 @@ package org.alfasoftware.astra.core.refactoring.imports;
 
 import static org.alfasoftware.astra.exampleTypes.A.STRING_VALUE_A;
 
+import org.alfasoftware.astra.core.refactoring.imports.ExampleTypeSamePackage.OtherInnerClass;
 import org.alfasoftware.astra.core.refactoring.imports.UnusedImportExampleAfter.InnerClassExample;
 import org.alfasoftware.astra.exampleTypes.A;
 import org.alfasoftware.astra.exampleTypes.C;
@@ -13,6 +14,8 @@ import org.junit.experimental.categories.Category;
 public class UnusedImportExampleAfter {
 
   A a = new A();
+  OtherInnerClass inner = new OtherInnerClass();
+
   /**
    * {@link C}
    * {@link D#one()}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExampleAfter.java
@@ -2,6 +2,8 @@ package org.alfasoftware.astra.core.refactoring.imports;
 
 import static org.alfasoftware.astra.exampleTypes.A.STRING_VALUE_A;
 
+import java.lang.Thread.State;
+
 import org.alfasoftware.astra.core.refactoring.imports.ExampleTypeSamePackage.OtherInnerClass;
 import org.alfasoftware.astra.core.refactoring.imports.UnusedImportExampleAfter.InnerClassExample;
 import org.alfasoftware.astra.exampleTypes.A;
@@ -15,6 +17,7 @@ public class UnusedImportExampleAfter {
 
   A a = new A();
   OtherInnerClass inner = new OtherInnerClass();
+  State baseState = State.RUNNABLE;
 
   /**
    * {@link C}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExampleAfter.java
@@ -11,6 +11,7 @@ import org.alfasoftware.astra.core.refactoring.imports.UnusedImportExampleAfter.
 import org.alfasoftware.astra.exampleTypes.A;
 import org.alfasoftware.astra.exampleTypes.C;
 import org.alfasoftware.astra.exampleTypes.D;
+import org.junit.*;
 import org.junit.experimental.categories.Category;
 
 @SuppressWarnings("unused")
@@ -30,6 +31,7 @@ public class UnusedImportExampleAfter {
     staticTwo();
     ExampleTypeSamePackage example = new ExampleTypeSamePackage();
     int r = Math.abs(-12);
+    Assert.assertEquals(12, r);
     return STRING_VALUE_A;
   }
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExampleAfter.java
@@ -1,8 +1,10 @@
 package org.alfasoftware.astra.core.refactoring.imports;
 
 import static org.alfasoftware.astra.exampleTypes.A.STRING_VALUE_A;
+import static org.alfasoftware.astra.exampleTypes.C.staticTwo;
 
 import java.lang.Thread.State;
+import java.lang.reflect.Method;
 
 import org.alfasoftware.astra.core.refactoring.imports.ExampleTypeSamePackage.OtherInnerClass;
 import org.alfasoftware.astra.core.refactoring.imports.UnusedImportExampleAfter.InnerClassExample;
@@ -18,12 +20,16 @@ public class UnusedImportExampleAfter {
   A a = new A();
   OtherInnerClass inner = new OtherInnerClass();
   State baseState = State.RUNNABLE;
+  Method methodRef;
 
   /**
    * {@link C}
    * {@link D#one()}
    */
   private String foo() {
+    staticTwo();
+    ExampleTypeSamePackage example = new ExampleTypeSamePackage();
+    int r = Math.abs(-12);
     return STRING_VALUE_A;
   }
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/imports/UnusedImportExampleAfter.java
@@ -1,10 +1,15 @@
 package org.alfasoftware.astra.core.refactoring.imports;
 
+import static org.alfasoftware.astra.exampleTypes.A.STRING_VALUE_A;
+
+import org.alfasoftware.astra.core.refactoring.imports.UnusedImportExampleAfter.InnerClassExample;
 import org.alfasoftware.astra.exampleTypes.A;
 import org.alfasoftware.astra.exampleTypes.C;
 import org.alfasoftware.astra.exampleTypes.D;
+import org.junit.experimental.categories.Category;
 
 @SuppressWarnings("unused")
+@Category(InnerClassExample.class)
 public class UnusedImportExampleAfter {
 
   A a = new A();
@@ -12,7 +17,12 @@ public class UnusedImportExampleAfter {
    * {@link C}
    * {@link D#one()}
    */
-  private void foo() {
+  private String foo() {
+    return STRING_VALUE_A;
+  }
+
+  static class InnerClassExample {
+
   }
 }
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/exampleTypes/A.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/exampleTypes/A.java
@@ -3,6 +3,8 @@ package org.alfasoftware.astra.exampleTypes;
 @SuppressWarnings("unused")
 public class A implements Fooable {
 
+  public static final String STRING_VALUE_A = "static string: A";
+
 	public void one() {
 
 	}
@@ -38,6 +40,6 @@ public class A implements Fooable {
 
   @Override
   public void doFoo() {
-    
+
   }
 }

--- a/astra-core/src/test/java/org/alfasoftware/astra/exampleTypes/C.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/exampleTypes/C.java
@@ -2,6 +2,8 @@ package org.alfasoftware.astra.exampleTypes;
 
 public class C {
 
+  public static final String STRING_VALUE_C = "static string: C";
+
 	public void one() {
 
 	}


### PR DESCRIPTION
Fixes #15 
Also extends the test coverage for UnusedImportExample to cover some static variables.