### PR TITLE
Type matcher parameterized supertypes

### DIFF
--- a/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/TypeMatcher.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/TypeMatcher.java
@@ -288,10 +288,16 @@ public class TypeMatcher implements Matcher {
     if (matches && typeBuilder.isFinal != null) {
       matches = checkIsFinal(typeDeclaration);
     }
-    if (matches) {
+    if (matches && typeBuilder.superClass != null) {
       Type superclassType = typeDeclaration.getSuperclassType();
-      if (superclassType != null) {
-        matches = AstraUtils.getFullyQualifiedName(superclassType).equals(typeBuilder.superClass);
+      // If the actual supertype is a parameterized type, and we're not specifically looking for a given parameterized type, then only look at the raw type
+      if (! typeBuilder.superClass.contains("<")) {
+        if (! typeDeclaration.getSuperclassType().resolveBinding().getBinaryName().equals(typeBuilder.superClass)) {
+          matches = false;
+        }
+        // Or if we do care about the parameterized type, then match on that too
+      } else if (! typeDeclaration.getSuperclassType().resolveBinding().getQualifiedName().equals(typeBuilder.superClass)) {
+        matches = false;
       }
     }
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestTypeMatcher.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestTypeMatcher.java
@@ -551,6 +551,58 @@ public class TestTypeMatcher {
     List<TypeDeclaration> typeDeclarations = visitor.getTypeDeclarations();
     assertTrue(matcher.matches(typeDeclarations.get(0)));
   }
+  
+  
+  @Test
+  public void testParameterizedTypeWithoutTypeParameterSpecified() {
+    // Given
+    String extendsMatcher = "package x;\r\n" +
+        "import java.util.List;\r\n" +
+        "public class Y extends List<Integer>{}";
+    
+    String extendsMatcherNoTypeParameter = "package x;\r\n" +
+        "import java.util.List;\r\n" +
+        "public class Y extends List{}";
+    
+    Matcher parameterizedTypeMatcher = TypeMatcher.builder()
+        .extending("java.util.List")
+        .build();
+    
+    // When
+    ClassVisitor visitor = parse(extendsMatcher);
+    ClassVisitor visitorNoTypeParameter = parse(extendsMatcherNoTypeParameter);
+    
+    // Then
+    List<TypeDeclaration> typeDeclarations = visitor.getTypeDeclarations();
+    assertTrue(parameterizedTypeMatcher.matches(typeDeclarations.get(0)));
+    typeDeclarations = visitorNoTypeParameter.getTypeDeclarations();
+    assertTrue(parameterizedTypeMatcher.matches(typeDeclarations.get(0)));
+  }
+  
+  
+  @Test
+  public void testParameterizedTypeWithTypeParameterSpecified() {
+    // Given
+    String extendsMatcher = "package x;\r\n" +
+        "import java.util.List;\r\n" +
+        "public class Y extends List<Integer>{}";
+    
+    Matcher parameterizedTypeMatcher = TypeMatcher.builder()
+        .extending("java.util.List<java.lang.Integer>")
+        .build();
+    
+    Matcher incorrectParameterizedTypeMatcher = TypeMatcher.builder()
+        .extending("java.util.List<java.lang.Long>")
+        .build();
+    
+    // When
+    ClassVisitor visitor = parse(extendsMatcher);
+    
+    // Then
+    List<TypeDeclaration> typeDeclarations = visitor.getTypeDeclarations();
+    assertTrue(parameterizedTypeMatcher.matches(typeDeclarations.get(0)));
+    assertFalse(incorrectParameterizedTypeMatcher.matches(typeDeclarations.get(0)));
+  }
 
 
   private ClassVisitor parse(String source) {


### PR DESCRIPTION
Ensure TypeMatcher can match either a subtype of a parameterized type with a specific type parameter or any subtype of a parameterized type regardless of the type parameter.