### PR TITLE
Type matcher parameterized supertypes

### DIFF
--- a/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/TypeMatcher.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/TypeMatcher.java
@@ -291,12 +291,14 @@ public class TypeMatcher implements Matcher {
     if (matches && typeBuilder.superClass != null) {
       Type superclassType = typeDeclaration.getSuperclassType();
       // If the actual supertype is a parameterized type, and we're not specifically looking for a given parameterized type, then only look at the raw type
-      if (! typeBuilder.superClass.contains("<")) {
-        if (! typeDeclaration.getSuperclassType().resolveBinding().getBinaryName().equals(typeBuilder.superClass)) {
+      if(superclassType == null) {
+        matches = false;
+      } else if (! typeBuilder.superClass.contains("<")) {
+        if (! typeBuilder.superClass.equals(superclassType.resolveBinding().getBinaryName())) {
           matches = false;
         }
         // Or if we do care about the parameterized type, then match on that too
-      } else if (! typeDeclaration.getSuperclassType().resolveBinding().getQualifiedName().equals(typeBuilder.superClass)) {
+      } else if (! typeBuilder.superClass.equals(superclassType.resolveBinding().getQualifiedName())) {
         matches = false;
       }
     }

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/TypeMatcher.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/TypeMatcher.java
@@ -290,15 +290,15 @@ public class TypeMatcher implements Matcher {
     }
     if (matches && typeBuilder.superClass != null) {
       Type superclassType = typeDeclaration.getSuperclassType();
-      // If the actual supertype is a parameterized type, and we're not specifically looking for a given parameterized type, then only look at the raw type
-      if(superclassType == null) {
+      if (superclassType == null || superclassType.resolveBinding() == null) {
         matches = false;
-      } else if (! typeBuilder.superClass.contains("<")) {
-        if (! typeBuilder.superClass.equals(superclassType.resolveBinding().getBinaryName())) {
+      // If we have specified a parameterized supertype, match on the qualified name
+      } else if (typeBuilder.superClass.contains("<")) {
+        if (! typeBuilder.superClass.equals(superclassType.resolveBinding().getQualifiedName())) {
           matches = false;
         }
-        // Or if we do care about the parameterized type, then match on that too
-      } else if (! typeBuilder.superClass.equals(superclassType.resolveBinding().getQualifiedName())) {
+      // If we have not specified a paramaterized supertype, then only match on binary type name
+      } else if (! typeBuilder.superClass.equals(superclassType.resolveBinding().getBinaryName())) {
         matches = false;
       }
     }

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestTypeMatcher.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestTypeMatcher.java
@@ -603,6 +603,25 @@ public class TestTypeMatcher {
     assertTrue(parameterizedTypeMatcher.matches(typeDeclarations.get(0)));
     assertFalse(incorrectParameterizedTypeMatcher.matches(typeDeclarations.get(0)));
   }
+  
+  
+  @Test
+  public void testTypeMatcherExtendingWhereNoSupertypePresent() {
+    // Given
+    String extendsMatcher = "package x;\r\n" +
+        "public class Y{}";
+    
+    Matcher parameterizedTypeMatcher = TypeMatcher.builder()
+        .extending("java.util.List")
+        .build();
+    
+    // When
+    ClassVisitor visitor = parse(extendsMatcher);
+    
+    // Then
+    List<TypeDeclaration> typeDeclarations = visitor.getTypeDeclarations();
+    assertFalse(parameterizedTypeMatcher.matches(typeDeclarations.get(0)));
+  }
 
 
   private ClassVisitor parse(String source) {


### PR DESCRIPTION
Handle case where the type for comparison does not have a super type. Add test to verify no error is thrown in this scenario.