### PR TITLE
Allow addition of a Class parameter to a method

### DIFF
--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/MethodInvocationRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/MethodInvocationRefactor.java
@@ -207,6 +207,9 @@ public class MethodInvocationRefactor implements ASTOperation {
       if (parameter.get().parameterLiteral instanceof String) {
         newArgument = methodInvocation.getAST().newStringLiteral();
         rewriter.set(newArgument, StringLiteral.ESCAPED_VALUE_PROPERTY, parameter.get().parameterLiteral, null);
+      } else if(parameter.get().parameterLiteral instanceof Class) {
+        newArgument = methodInvocation.getAST().newStringLiteral();
+        rewriter.set(newArgument, StringLiteral.ESCAPED_VALUE_PROPERTY, ((Class<?>) parameter.get().parameterLiteral).getSimpleName()+".class", null);
       } else {
         // Unfortunately have to handle each argument type individually.
         // Hopefully once primitives and general object types are covered, this will be less of a pain.


### PR DESCRIPTION
@RadikalJin - this allows the addition of class arguments in MethodInvocationRefactor without needing to always specify strings.