### PR TITLE
Allow multiple files in --cp

### DIFF
--- a/astra-cli/src/main/java/org/alfasoftware/astracli/commandline/AstraChangeType.java
+++ b/astra-cli/src/main/java/org/alfasoftware/astracli/commandline/AstraChangeType.java
@@ -40,7 +40,8 @@ class AstraChangeType implements Runnable {
   @Option(
     names = {"-c", "--cp"},
     required = true,
-    description = "Set the path to the additional jar files. At least the jar containing the 'before' type should be specified.")
+    description = "Set the path to the additional jar files. At least the jar containing the 'before' type should be specified.",
+    split = "[,;]")
   File[] classpath;
 
     @Override

--- a/astra-cli/src/main/java/org/alfasoftware/astracli/commandline/AstraMethodInvocation.java
+++ b/astra-cli/src/main/java/org/alfasoftware/astracli/commandline/AstraMethodInvocation.java
@@ -81,7 +81,8 @@ class AstraMethodInvocation implements Runnable {
     @CommandLine.Option(
       names = "--cp",
       required = true,
-      description = "Set the path to the additional jar files. At least the jar containing the 'before' type should be specified.")
+      description = "Set the path to the additional jar files. At least the jar containing the 'before' type should be specified.",
+      split = "[,;]")
     File[] classpath;
 
 


### PR DESCRIPTION
This fixes issue #14. 

I have not written or elaborated upon any unit tests. In my opinion, picocli lends itself poorly to testing - I could not find a way to reasonably verify the results without actually executing them, and I think white-box testing such a small change that can easily be verified via debugger or manually is overkill. Nonetheless, if there are ways to easily access a parsed instance of e.g. `AstraMethodInvocation` I will augment these changes with respective unit tests.

Additionally, I have not touched anything related to versioning, since it does not mention how releases are handled in the contributing guidelines.