### PR TITLE
Don't remove import when changing a static method by name only, as we…

### DIFF
--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/MethodInvocationRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/MethodInvocationRefactor.java
@@ -169,8 +169,6 @@ public class MethodInvocationRefactor implements ASTOperation {
             rewriter.set(methodInvocation, MethodInvocation.EXPRESSION_PROPERTY, newName, null);
             rewriter.set(methodInvocation.getName(), SimpleName.IDENTIFIER_PROPERTY, methodName, null);
           } else {
-            removeImport(compilationUnit, 
-              getFullyQualifiedName(methodInvocation, compilationUnit) + "." + methodInvocation.getName().toString(), rewriter);
             addStaticImport(compilationUnit, afterTypeFQ + "." + methodName, rewriter);
             rewriter.set(methodInvocation.getName(), SimpleName.IDENTIFIER_PROPERTY, methodName, null);
           }


### PR DESCRIPTION
… may not be changing all invocations of this method.

Instead, leave the import and let the UnusedImportRefactor clean it up if necessary.