### PR TITLE
Added compatibility for fully qualified names in Javadoc in TypeReferenceRefactor.

### DIFF
--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/TypeReferenceRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/TypeReferenceRefactor.java
@@ -205,7 +205,8 @@ public class TypeReferenceRefactor implements ASTOperation {
           else if (f instanceof QualifiedName) {
             Optional.of(f)
               .map(QualifiedName.class::cast)
-              .map(QualifiedName::getQualifier)
+              .map(QualifiedName::getFullyQualifiedName)
+              .filter(n -> n.equals(getFromType()))
               .ifPresent(t -> types.add((QualifiedName) f));
           }
           else if (f instanceof MethodRef) {

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/TypeReferenceRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/TypeReferenceRefactor.java
@@ -201,15 +201,15 @@ public class TypeReferenceRefactor implements ASTOperation {
               .map(ITypeBinding::getQualifiedName)
               .filter(n -> n.equals(getFromType()))
               .ifPresent(t -> types.add((SimpleName) f));
-          }
-          else if (f instanceof QualifiedName) {
+            
+          } else if (f instanceof QualifiedName) {
             Optional.of(f)
               .map(QualifiedName.class::cast)
               .map(QualifiedName::getFullyQualifiedName)
               .filter(n -> n.equals(getFromType()))
               .ifPresent(t -> types.add((QualifiedName) f));
-          }
-          else if (f instanceof MethodRef) {
+            
+          } else if (f instanceof MethodRef) {
             Optional.of(f)
               .map(MethodRef.class::cast)
               .map(MethodRef::getQualifier)

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/TypeReferenceRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/TypeReferenceRefactor.java
@@ -201,7 +201,16 @@ public class TypeReferenceRefactor implements ASTOperation {
               .map(ITypeBinding::getQualifiedName)
               .filter(n -> n.equals(getFromType()))
               .ifPresent(t -> types.add((SimpleName) f));
-          } else if (f instanceof MethodRef) {
+          }
+          else if (f instanceof QualifiedName) {
+            Optional.of(f)
+              .map(QualifiedName.class::cast)
+              .map(QualifiedName::resolveTypeBinding)
+              .map(ITypeBinding::getQualifiedName)
+              .filter(n -> n.equals(getFromType()))
+              .ifPresent(t -> types.add((QualifiedName) f));
+          }
+          else if (f instanceof MethodRef) {
             Optional.of(f)
               .map(MethodRef.class::cast)
               .map(MethodRef::getQualifier)

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/TypeReferenceRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/TypeReferenceRefactor.java
@@ -205,9 +205,7 @@ public class TypeReferenceRefactor implements ASTOperation {
           else if (f instanceof QualifiedName) {
             Optional.of(f)
               .map(QualifiedName.class::cast)
-              .map(QualifiedName::resolveTypeBinding)
-              .map(ITypeBinding::getQualifiedName)
-              .filter(n -> n.equals(getFromType()))
+              .map(QualifiedName::getQualifier)
               .ifPresent(t -> types.add((QualifiedName) f));
           }
           else if (f instanceof MethodRef) {

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TestTypeReferenceRefactor.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TestTypeReferenceRefactor.java
@@ -84,6 +84,20 @@ public class TestTypeReferenceRefactor extends AbstractRefactorTest {
             .toType(EnumB.class.getName())
             .build())));
   }
+  
+  
+  /**
+   * This test checks that where the fully qualified names don't match, the types are not refactored.
+   */
+  @Test
+  public void testChangeTypesNegativeExample() {
+    assertRefactor(TypeReferenceNegativeExample.class,
+        new HashSet<>(Arrays.asList(
+          TypeReferenceRefactor.builder()
+            .fromType(A.class.getName())
+            .toType(B.class.getName())
+            .build())));
+  }
 
 
   /**

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceExample.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceExample.java
@@ -6,6 +6,7 @@ import org.alfasoftware.astra.exampleTypes.A;
 
 /**
  * {@link A}
+ * {@link org.alfasoftware.astra.exampleTypes.A}
  */
 public class TypeReferenceExample extends A {
   A field = new A();

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceExample.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceExample.java
@@ -3,10 +3,13 @@ package org.alfasoftware.astra.core.refactoring.types;
 import java.util.List;
 
 import org.alfasoftware.astra.exampleTypes.A;
+import org.alfasoftware.astra.exampleTypes.C;
 
 /**
  * {@link A}
+ * {@link C}
  * {@link org.alfasoftware.astra.exampleTypes.A}
+ * {@link org.alfasoftware.astra.exampleTypes.C}
  */
 public class TypeReferenceExample extends A {
   A field = new A();

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceExampleAfter.java
@@ -3,10 +3,13 @@ package org.alfasoftware.astra.core.refactoring.types;
 import java.util.List;
 
 import org.alfasoftware.astra.exampleTypes.B;
+import org.alfasoftware.astra.exampleTypes.C;
 
 /**
  * {@link B}
+ * {@link C}
  * {@link org.alfasoftware.astra.exampleTypes.B}
+ * {@link org.alfasoftware.astra.exampleTypes.C}
  */
 public class TypeReferenceExampleAfter extends B {
   B field = new B();

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceExampleAfter.java
@@ -6,6 +6,7 @@ import org.alfasoftware.astra.exampleTypes.B;
 
 /**
  * {@link B}
+ * {@link org.alfasoftware.astra.exampleTypes.B}
  */
 public class TypeReferenceExampleAfter extends B {
   B field = new B();

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceNegativeExample.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceNegativeExample.java
@@ -1,0 +1,41 @@
+package org.alfasoftware.astra.core.refactoring.types;
+
+import java.util.List;
+
+import org.alfasoftware.astra.exampleTypes.C;
+import org.alfasoftware.astra.exampleTypes.a.A;
+
+/**
+ * Nothing should be changed in this class
+ * 
+ * {@link A}
+ * {@link C}
+ * {@link org.alfasoftware.astra.exampleTypes.a.A}
+ * {@link org.alfasoftware.astra.exampleTypes.C}
+ */
+public class TypeReferenceNegativeExample extends A {
+  A field = new A();
+  C field2 = new C();
+  A[] fieldArray = new A[0];
+  C[] fieldArray2 = new C[0];
+
+  @SuppressWarnings({ "unused", "rawtypes" })
+  public <T extends A> T generic(T n, List<? super A> in) {
+    org.alfasoftware.astra.exampleTypes.a.A.staticOne();
+    org.alfasoftware.astra.exampleTypes.C.staticOne();
+    A.staticOne();
+    C.staticOne();
+    this.<A>generic(null, null);
+    Class clazz = A.class;
+    Class clazz2 = C.class;
+    return n;
+  }
+
+  public A parameter(A param) {
+    return param;
+  }
+  
+  public C parameter2(C param) {
+    return param;
+  }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceNegativeExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceNegativeExampleAfter.java
@@ -1,0 +1,41 @@
+package org.alfasoftware.astra.core.refactoring.types;
+
+import java.util.List;
+
+import org.alfasoftware.astra.exampleTypes.C;
+import org.alfasoftware.astra.exampleTypes.a.A;
+
+/**
+ * Nothing should be changed in this class
+ * 
+ * {@link A}
+ * {@link C}
+ * {@link org.alfasoftware.astra.exampleTypes.a.A}
+ * {@link org.alfasoftware.astra.exampleTypes.C}
+ */
+public class TypeReferenceNegativeExampleAfter extends A {
+  A field = new A();
+  C field2 = new C();
+  A[] fieldArray = new A[0];
+  C[] fieldArray2 = new C[0];
+
+  @SuppressWarnings({ "unused", "rawtypes" })
+  public <T extends A> T generic(T n, List<? super A> in) {
+    org.alfasoftware.astra.exampleTypes.a.A.staticOne();
+    org.alfasoftware.astra.exampleTypes.C.staticOne();
+    A.staticOne();
+    C.staticOne();
+    this.<A>generic(null, null);
+    Class clazz = A.class;
+    Class clazz2 = C.class;
+    return n;
+  }
+
+  public A parameter(A param) {
+    return param;
+  }
+  
+  public C parameter2(C param) {
+    return param;
+  }
+}


### PR DESCRIPTION
testChangeTypes() now passes and includes fully qualified name types as the issue mentioned.