### PR TITLE
Fix/issue 103 reduce cognitive complexity of AnnotationChangeRefactor#removeMembersFromAnnotation

### DIFF
--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/annotations/AnnotationChangeRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/annotations/AnnotationChangeRefactor.java
@@ -216,10 +216,9 @@ public class AnnotationChangeRefactor implements ASTOperation {
   private Annotation removeMembersFromAnnotation(ASTRewrite rewriter, Annotation annotation) {
     if (namesForMembersToRemove.isEmpty()){
       return annotation;
-    }
-    if ( annotation.isSingleMemberAnnotation() && namesForMembersToRemove.contains(VALUE)) {
+    } else if ( annotation.isSingleMemberAnnotation() && namesForMembersToRemove.contains(VALUE)) {
       return convertAnnotationToMarkerAnnotation(rewriter, annotation);
-    } else if(annotation.isNormalAnnotation()) {
+    } else if (annotation.isNormalAnnotation()) {
       NormalAnnotation normalAnnotation = (NormalAnnotation) annotation;
       final ListRewrite listRewrite = rewriter.getListRewrite(normalAnnotation, NormalAnnotation.VALUES_PROPERTY);
       @SuppressWarnings("unchecked")

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/annotations/AnnotationChangeRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/annotations/AnnotationChangeRefactor.java
@@ -214,24 +214,25 @@ public class AnnotationChangeRefactor implements ASTOperation {
 
 
   private Annotation removeMembersFromAnnotation(ASTRewrite rewriter, Annotation annotation) {
-    if (!namesForMembersToRemove.isEmpty()){
-      if (annotation.isSingleMemberAnnotation() && namesForMembersToRemove.contains(VALUE)) {
+    if (namesForMembersToRemove.isEmpty()){
+      return annotation;
+    }
+    if ( annotation.isSingleMemberAnnotation() && namesForMembersToRemove.contains(VALUE)) {
+      return convertAnnotationToMarkerAnnotation(rewriter, annotation);
+    } else if(annotation.isNormalAnnotation()) {
+      NormalAnnotation normalAnnotation = (NormalAnnotation) annotation;
+      final ListRewrite listRewrite = rewriter.getListRewrite(normalAnnotation, NormalAnnotation.VALUES_PROPERTY);
+      @SuppressWarnings("unchecked")
+      final List<MemberValuePair> rewrittenList = listRewrite.getRewrittenList();
+      for (MemberValuePair memberValuePair : rewrittenList) {
+        if(namesForMembersToRemove.contains(memberValuePair.getName().getIdentifier())){
+          listRewrite.remove(memberValuePair, null);
+        }
+      }
+      if (listRewrite.getRewrittenList().isEmpty()) {
         return convertAnnotationToMarkerAnnotation(rewriter, annotation);
-      } else if(annotation.isNormalAnnotation()) {
-        NormalAnnotation normalAnnotation = (NormalAnnotation) annotation;
-        final ListRewrite listRewrite = rewriter.getListRewrite(normalAnnotation, NormalAnnotation.VALUES_PROPERTY);
-        @SuppressWarnings("unchecked")
-        final List<MemberValuePair> rewrittenList = listRewrite.getRewrittenList();
-        for (MemberValuePair memberValuePair : rewrittenList) {
-          if(namesForMembersToRemove.contains(memberValuePair.getName().getIdentifier())){
-            listRewrite.remove(memberValuePair, null);
-          }
-        }
-        if (listRewrite.getRewrittenList().isEmpty()) {
-          return convertAnnotationToMarkerAnnotation(rewriter, annotation);
-        } else {
-          return normalAnnotation;
-        }
+      } else {
+        return normalAnnotation;
       }
     }
     return annotation;


### PR DESCRIPTION
Fixes  #103

Changes proposed in this PR:

- isolated the namesForMembersToRemove being empty condition in order to reduce nesting level.