### PR TITLE
90 Add coverage information with sonar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,12 @@
                   <goal>prepare-agent</goal>
                 </goals>
               </execution>
+              <execution>
+                <id>jacoco-report</id>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
             </executions>
           </plugin>
         </plugins>


### PR DESCRIPTION
<h1>Issue#90: Add coverage information with sonar</h1>
<p>Ciao! regarding this issue - apparently goal for code coverage report was missing in pom.xml. After adding the goal was able to capture the code coverage on sonarqube running locally. If it sounds useful then definitely check it out.</p>
<p>:crossed_fingers: Hope this helps </p>

![astra1](https://user-images.githubusercontent.com/37650480/185610246-0442e8d8-0669-4a33-a6b6-ae298f02d54e.jpg)

![astra2](https://user-images.githubusercontent.com/37650480/185610260-f8250854-e1ce-45a7-a3e2-9e8434fa5e1d.jpg)


