### PR TITLE
UpdateTypeRefactor to move source code files

### DIFF
--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/javapattern/JavaPatternFileParser.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/javapattern/JavaPatternFileParser.java
@@ -43,7 +43,7 @@ class JavaPatternFileParser {
 
   public void buildMatchersWithSourcesAndClassPath(File javaFile, String[] sources, String[] classpath) throws IOException {
     String matcherFile = new String(Files.readAllBytes(Paths.get(javaFile.getAbsolutePath())));
-    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(matcherFile, sources, classpath);
+    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(javaFile, matcherFile, sources, classpath);
 
     MethodDeclarationVisitor visitor = new MethodDeclarationVisitor();
     compilationUnit.accept(visitor);

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/InlineInterfaceRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/InlineInterfaceRefactor.java
@@ -4,6 +4,7 @@ import static org.alfasoftware.astra.core.utils.AstraUtils.addImport;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.AbstractMap;
 import java.util.Collection;
@@ -52,8 +53,10 @@ public class InlineInterfaceRefactor implements ASTOperation {
   public InlineInterfaceRefactor(String interfaceName, String interfacePath) {
     this.interfaceName = interfaceName;
     try {
+      Path filePath = Paths.get(interfacePath);
       final CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(
-          new String(Files.readAllBytes(Paths.get(interfacePath))),
+          filePath.toFile(),
+          new String(Files.readAllBytes(filePath)),
           new String[] {""}, new String[] {System.getProperty("java.home") + "/lib/rt.jar"});
       interfaceVisitor = new ClassVisitor();
       compilationUnit.accept(interfaceVisitor);

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/UpdateTypeRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/UpdateTypeRefactor.java
@@ -1,30 +1,41 @@
 package org.alfasoftware.astra.core.refactoring.operations.types;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.stream.Stream;
 
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraUtils;
 import org.alfasoftware.astra.core.utils.ClassVisitor;
+import org.alfasoftware.astra.core.utils.CompilationUnitProperty;
 import org.apache.log4j.Logger;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.text.edits.MalformedTreeException;
 
 /**
- * While the {@link TypeReferenceRefactor} will update references of one type and change it to another,
- * special handling is needed to update the type itself.
- * 
- * For example, the package declaration at the top of the file will need to be updated, 
- * and imports might need to be added for types that may not previously have been imported due to being in the same package.
- * 
- * Note that this doesn't currently move the file - the package declaration will be updated, 
- * but the file itself will still live in the folder matching the "fromType". 
- * This means that the version control move will need to be performed manually outside Astra.
+ * Moves a file to the specified 'toType' location. Makes all the necessary updates on referencing classes.
+ * <h3>Actions that will be performed on the 'fromType' class:</h3>
+ * <ul>
+ *   <li>Update package declaration</li>
+ *   <li>Rename type (if necessary)</li>
+ *   <li>Update internal references to itself (if necessary)</li>
+ *   <li>Update all types referencing refactored type</li>
+ * </ul>
+ *
+ * Limitation: this operation does <b>not</b> currently move the <b>nested types</b>. In scenarios where a nested class is specified
+ * to be moved, this operation will still update types referencing the nested class, but the actual movement has
+ * to be performed manually.
  */
 public class UpdateTypeRefactor implements ASTOperation {
 
@@ -85,21 +96,79 @@ public class UpdateTypeRefactor implements ASTOperation {
   @Override
   public void run(CompilationUnit compilationUnit, ASTNode node, ASTRewrite rewriter)
       throws IOException, MalformedTreeException, BadLocationException {
-    
-    // If it is the type we're changing
-    if (node instanceof TypeDeclaration) {
-      TypeDeclaration typeDeclaration = (TypeDeclaration) node;
-      if (AstraUtils.getFullyQualifiedName(typeDeclaration).equals(fromType) &&
-          // and if we're updating the package name
-          ! AstraUtils.getPackageName(fromType).equals(AstraUtils.getPackageName(toType))) {
-        
+
+    if (fromType.equals(toType)) {
+      return;
+    }
+
+    // If it is the fromType we're changing
+    if (node instanceof TypeDeclaration && AstraUtils.getFullyQualifiedName((TypeDeclaration) node).equals(fromType)) {
+
+      boolean isNewPackage = !AstraUtils.getPackageName(fromType).equals(AstraUtils.getPackageName(toType));
+      if (isNewPackage) {
         updatePackageDeclaration(compilationUnit, rewriter);
         addImportsFromOldPackage(compilationUnit, rewriter);
       }
-      
+
+      moveType(compilationUnit, node, rewriter);
+
     } else {
       typeReferenceRefactor.run(compilationUnit, node, rewriter);
     }
+
+  }
+
+  private static boolean isInnerType(ASTNode node) {
+    return node.getParent() instanceof TypeDeclaration;
+  }
+
+  /**
+   * Applies any necessary rename operations on the file content and moves the underline Java source file to its new location.
+   */
+  private void moveType(CompilationUnit compilationUnit, ASTNode node, ASTRewrite rewriter) {
+    if (isInnerType(node)) {
+      log.warn(String.format("Moving inner types is currently not supported. Skipping moving [%s]", AstraUtils.getNameForCompilationUnit(compilationUnit)));
+      return;
+    }
+
+    try {
+      Path fileAbsolutePath = Path.of((String) compilationUnit.getProperty(CompilationUnitProperty.ABSOLUTE_PATH));
+
+      // Compute new file location
+      String fromTypePath = fromType.replace(".", File.separator);
+      String toTypePath = toType.replace(".", File.separator);
+      Path fileNewPath = Path.of(fileAbsolutePath.toString().replace(fromTypePath, toTypePath));
+      fileNewPath.getParent().toFile().mkdirs();
+
+      // Create the new Java file
+      updateInternalTypeReferences(compilationUnit, rewriter);
+      String content = AstraUtils.makeChangesFromAST(new String(Files.readAllBytes(fileAbsolutePath)), rewriter);
+      Files.write(fileNewPath, content.getBytes(), StandardOpenOption.CREATE);
+
+      // Delete old file
+      Files.delete(fileAbsolutePath);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Updates references to the {@link UpdateTypeRefactor#fromType} type to itself.
+   * For example, nested classes can reference the parent class being refactored.
+   */
+  private void updateInternalTypeReferences(CompilationUnit compilationUnit, ASTRewrite rewriter) {
+    final ClassVisitor visitor = new ClassVisitor();
+    compilationUnit.accept(visitor);
+    visitor.getVisitedNodes().forEach(visitedNode -> {
+      if (visitedNode instanceof SimpleName) {
+        IBinding binding = ((SimpleName) visitedNode).resolveBinding();
+        if (binding instanceof ITypeBinding && ((ITypeBinding) binding).getQualifiedName().equals(getFromType())) {
+          log.info("Refactoring simple type [" + visitedNode + "] to [" + AstraUtils.getSimpleName(toType) + "] in [" +
+              AstraUtils.getNameForCompilationUnit(compilationUnit) + "]");
+          rewriter.set(visitedNode, SimpleName.IDENTIFIER_PROPERTY, AstraUtils.getSimpleName(toType), null);
+        }
+      }
+    });
   }
   
   

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/utils/AstraUtils.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/utils/AstraUtils.java
@@ -1,5 +1,6 @@
 package org.alfasoftware.astra.core.utils;
 
+import java.io.File;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -57,10 +58,11 @@ public class AstraUtils {
   private static final Logger log = Logger.getLogger(AstraUtils.class);
   public static final String CLASSPATHS_MISSING_WARNING = "This may be a sign that classpaths for the operation need to be supplied. ";
 
-  public static CompilationUnit readAsCompilationUnit(String fileSource, String[] sources, String[] classPath) {
+  public static CompilationUnit readAsCompilationUnit(File file, String fileSource, String[] sources, String[] classPath) {
     ASTParser parser = createParser(fileSource, sources, classPath);
 
     CompilationUnit compilationUnit = (CompilationUnit) parser.createAST(null);
+    compilationUnit.setProperty(CompilationUnitProperty.ABSOLUTE_PATH, file.getAbsolutePath());
     compilationUnit.recordModifications();
     return compilationUnit;
   }

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/utils/CompilationUnitProperty.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/utils/CompilationUnitProperty.java
@@ -1,0 +1,18 @@
+package org.alfasoftware.astra.core.utils;
+
+import org.eclipse.jdt.core.dom.CompilationUnit;
+
+/**
+ * Constant class for Astra specific {@link CompilationUnit} properties.
+ */
+public final class CompilationUnitProperty {
+  private CompilationUnitProperty() {
+    // Constant class, do not instantiate.
+  }
+
+  /**
+   * The absolute path of the source file used to generate the respective {@link CompilationUnit}.
+   * Return Type: {@link String}.
+   */
+  public static final String ABSOLUTE_PATH = "absolute_path";
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/analysis/AbstractAnalysisTest.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/analysis/AbstractAnalysisTest.java
@@ -49,7 +49,7 @@ public abstract class AbstractAnalysisTest {
     try {
       File file = new File(TEST_EXAMPLES + "/" + fileToAnalyse.getName().replaceAll("\\.", "/") + ".java");
       String fileContent = new String(Files.readAllBytes(Paths.get(file.getAbsolutePath())));
-      new AstraCore().applyOperationsToFile(fileContent, Collections.singleton(analysisOperation), sources, classPath);
+      new AstraCore().applyOperationsToFile(file, fileContent, Collections.singleton(analysisOperation), sources, classPath);
     } catch (IOException | BadLocationException e) {
       fail();
     }

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestAnnotationMatcher.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestAnnotationMatcher.java
@@ -1,5 +1,6 @@
 package org.alfasoftware.astra.core.matchers;
 
+import java.io.File;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -221,7 +222,7 @@ public class TestAnnotationMatcher {
   }
 
   private ClassVisitor parse(String source) {
-    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(source, new String[] {TEST_SOURCE}, UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
+    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(new File(""), source, new String[]{TEST_SOURCE}, UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
     ClassVisitor visitor = new ClassVisitor();
     compilationUnit.accept(visitor);
     return visitor;

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestMethodMatcher.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestMethodMatcher.java
@@ -316,7 +316,7 @@ public class TestMethodMatcher {
       fail("IOException when reading file : " + e);
     }
 
-    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(fileContentBefore, new String[] {TEST_SOURCE}, UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
+    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(new File(""), fileContentBefore, new String[]{TEST_SOURCE}, UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
 
     final ClassVisitor visitor = new ClassVisitor();
     compilationUnit.accept(visitor);

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestTypeMatcher.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestTypeMatcher.java
@@ -3,6 +3,7 @@ package org.alfasoftware.astra.core.matchers;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
 
+import java.io.File;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -723,7 +724,7 @@ public class TestTypeMatcher {
 
 
   private ClassVisitor parse(String source) {
-    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(source, new String[] {TEST_SOURCE}, UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
+    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(new File(""), source, new String[]{TEST_SOURCE}, UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
     ClassVisitor visitor = new ClassVisitor();
     compilationUnit.accept(visitor);
     return visitor;

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/AbstractRefactorTest.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/AbstractRefactorTest.java
@@ -50,7 +50,7 @@ public abstract class AbstractRefactorTest {
     try {
       String fileContentBefore = new String(Files.readAllBytes(before.toPath()));
       String expectedAfter = new String(Files.readAllBytes(after.toPath()));
-      String expectedBefore = new AstraCore().applyOperationsToFile(fileContentBefore, refactors, sources, classPath)
+      String expectedBefore = new AstraCore().applyOperationsToFile(before, fileContentBefore, refactors, sources, classPath)
         .replaceAll(beforeClass.getSimpleName(), beforeClass.getSimpleName() + "After");
 
       expectedBefore = changesToApplyToBefore.apply(expectedBefore);
@@ -77,7 +77,7 @@ public abstract class AbstractRefactorTest {
     try {
       String fileContentBefore = new String(Files.readAllBytes(before.toPath()));
       String expectedAfter = new String(Files.readAllBytes(after.toPath()));
-      String expectedBefore = new AstraCore().applyOperationsToFile(fileContentBefore, refactors, sources, classPath).replaceAll(beforeClassSimpleName, beforeClassSimpleName + "After");
+      String expectedBefore = new AstraCore().applyOperationsToFile(before, fileContentBefore, refactors, sources, classPath).replaceAll(beforeClassSimpleName, beforeClassSimpleName + "After");
       expectedBefore = this.changesToApplyToBefore.apply(expectedBefore);
       assertEquals(expectedAfter, expectedBefore);
     } catch (BadLocationException | IOException exception) {

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TestUpdateTypeRefactor.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TestUpdateTypeRefactor.java
@@ -17,9 +17,14 @@ import org.alfasoftware.astra.core.refactoring.types.newpackage.UpdatedTypeExamp
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraCore;
 import org.eclipse.jface.text.BadLocationException;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class TestUpdateTypeRefactor extends AbstractRefactorTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   /**
    * Verify that the "from" type itself is updated correctly - this means:
@@ -34,7 +39,7 @@ public class TestUpdateTypeRefactor extends AbstractRefactorTest {
    */
   @Test
   @SuppressWarnings("rawtypes")
-  public void testUpdateTypeNameAndPackageInFromFile() {
+  public void testUpdateTypeNameAndPackageInFromFile() throws IOException {
     
     Class beforeClass = UpdateTypeToChangeExample.class;
     Class afterClass = UpdatedTypeExampleAfter.class;
@@ -45,19 +50,24 @@ public class TestUpdateTypeRefactor extends AbstractRefactorTest {
         .toType(afterClass.getName())
         .build()
     ));
-    
+
+    File temporaryFolderRoot = temporaryFolder.getRoot();
     
     File before = new File(TEST_EXAMPLES + "/" + beforeClass.getName().replaceAll("\\.", "/") + ".java");
+    File beforeTmpFile = Files.copy(before.toPath(), temporaryFolderRoot.toPath().resolve(before.getName())).toFile();
     File after = new File(TEST_EXAMPLES + "/" + afterClass.getName().replaceAll("\\.", "/") + ".java");
+    File afterTmpFile = Files.copy(after.toPath(), temporaryFolderRoot.toPath().resolve(after.getName())).toFile();
 
     try {
-      String fileContentBefore = new String(Files.readAllBytes(before.toPath()));
-      String expectedAfter = new String(Files.readAllBytes(after.toPath()));
+      String fileContentBefore = new String(Files.readAllBytes(beforeTmpFile.toPath()));
+      String expectedAfter = new String(Files.readAllBytes(afterTmpFile.toPath()));
       String expectedBefore = new AstraCore().applyOperationsToFile(
-        fileContentBefore, 
-        operations, 
-        new HashSet<>(Arrays.asList(TEST_SOURCE)).toArray(new String[0]),
-        UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
+          beforeTmpFile,
+          fileContentBefore,
+          operations,
+          new HashSet<>(Arrays.asList(TEST_SOURCE)).toArray(new String[0]),
+          UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0])
+      );
 
       expectedBefore = changesToApplyToBefore.apply(expectedBefore);
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/utils/TestAstraUtils.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/utils/TestAstraUtils.java
@@ -153,15 +153,17 @@ public class TestAstraUtils {
     private static final String TEST_SOURCE = Paths.get(".").toAbsolutePath().normalize().toString().concat("/src/test/java");
     private static final String TEST_EXAMPLES = "./src/test/java";
 
+    private final File before;
     private final String source;
 
 
     TestingSourceParser(String source) {
+      this.before = new File("");
       this.source = source;
     }
 
     TestingSourceParser(Class<?> source) throws IOException {
-      File before = new File(TEST_EXAMPLES + "/" + source.getName().replaceAll("\\.", "/") + ".java");
+      this.before = new File(TEST_EXAMPLES + "/" + source.getName().replaceAll("\\.", "/") + ".java");
       this.source = new String(Files.readAllBytes(before.toPath()));
     }
 
@@ -173,7 +175,7 @@ public class TestAstraUtils {
     }
 
     CompilationUnit buildCompilationUnit() {
-      return AstraUtils.readAsCompilationUnit(source, new String[]{SOURCE, TEST_SOURCE}, UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
+      return AstraUtils.readAsCompilationUnit(before, source, new String[]{SOURCE, TEST_SOURCE}, UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
     }
   }
 


### PR DESCRIPTION
<ins>This Pull Request includes the following high level changes:</ins>

* UpdateTypeRefactor will now move files to their new location.
    * This is limited to top level types. When moving a nested class, no file movement will be performed
    * This is limited to moving classes in the same module. Can not move a class across different modules.
* Introduced CompilationUnitProperty to allow high level metadata to be appended on generated CompilationUnit instances.
    * In this case we are using this to communicate the absolute path of the source file to be used for the move operation.
* AstraUtils.readAsCompilationUnit is changed to accept File object. This is how we add the File's absolute path on the generated CompilationUnit as a property (using CompilationUnitProperty#ABSOLUTE_PATH as the key).
