### PR TITLE
Annotation change refactor - enable setting type literals 

### DIFF
--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/annotations/AnnotationChangeRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/annotations/AnnotationChangeRefactor.java
@@ -1,6 +1,7 @@
 package org.alfasoftware.astra.core.refactoring.operations.annotations;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -348,34 +349,34 @@ public class AnnotationChangeRefactor implements ASTOperation {
     List<MemberValuePair> originalMembers = listRewrite.getOriginalList();
     final List<String> originalMemberNames = originalMembers.stream().map(memberValuePair -> memberValuePair.getName().getIdentifier()).collect(Collectors.toList());
 
-    membersAndValuesToAdd.forEach((memberName, value) -> {
-      if(originalMemberNames.contains(memberName)) {
-        logWarning(compilationUnit, memberName);
+    membersAndValuesToAdd.entrySet().stream().sorted(Map.Entry.comparingByKey()).forEach(entry -> {
+      if(originalMemberNames.contains(entry.getKey())) {
+        logWarning(compilationUnit, entry.getKey());
         return;
       }
       MemberValuePair newMemberAndValue = rewriter.getAST().newMemberValuePair();
-      newMemberAndValue.setName(rewriter.getAST().newSimpleName(memberName));
+      newMemberAndValue.setName(rewriter.getAST().newSimpleName(entry.getKey()));
       final StringLiteral valueLiteral = rewriter.getAST().newStringLiteral();
-      valueLiteral.setLiteralValue(value);
+      valueLiteral.setLiteralValue(entry.getValue());
       newMemberAndValue.setValue(valueLiteral);
       listRewrite.insertLast(newMemberAndValue, null);
     });
 
-    membersAndTypesToAdd.forEach((memberName, value) -> {
-      if(originalMemberNames.contains(memberName)) {
-        logWarning(compilationUnit, memberName);
+    membersAndTypesToAdd.entrySet().stream().sorted(Map.Entry.comparingByKey()).forEach(entry -> {
+      if(originalMemberNames.contains(entry.getKey())) {
+        logWarning(compilationUnit, entry.getKey());
         return;
       }
       MemberValuePair newMemberAndValue = rewriter.getAST().newMemberValuePair();
-      newMemberAndValue.setName(rewriter.getAST().newSimpleName(memberName));
+      newMemberAndValue.setName(rewriter.getAST().newSimpleName(entry.getKey()));
       final TypeLiteral typeLiteral = rewriter.getAST().newTypeLiteral();
 
       // Handle both qualified and simple types
-      if (value.contains(".")) {
-        String[] qualifiedName = value.split("\\.");
+      if (entry.getValue().contains(".")) {
+        String[] qualifiedName = entry.getValue().split("\\.");
         typeLiteral.setType(rewriter.getAST().newNameQualifiedType(rewriter.getAST().newName(qualifiedName[0]), rewriter.getAST().newSimpleName(qualifiedName[1])));
       } else {
-        typeLiteral.setType(rewriter.getAST().newSimpleType(rewriter.getAST().newSimpleName(value)));
+        typeLiteral.setType(rewriter.getAST().newSimpleType(rewriter.getAST().newSimpleName(entry.getValue())));
       }
 
       newMemberAndValue.setValue(typeLiteral);

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/annotations/AnnotationChangeRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/annotations/AnnotationChangeRefactor.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.NormalAnnotation;
 import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
 import org.eclipse.jdt.core.dom.StringLiteral;
+import org.eclipse.jdt.core.dom.TypeLiteral;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jface.text.BadLocationException;
@@ -40,15 +41,17 @@ public class AnnotationChangeRefactor implements ASTOperation {
   private final AnnotationMatcher fromType;
   private final String toType;
   private final Map<String, String> membersAndValuesToAdd;
+  private final Map<String, String> membersAndTypesToAdd;
   private final Set<String> namesForMembersToRemove;
   private final Map<String, String> memberNameUpdates;
   private final Map<String, String> memberNamesToUpdateWithNewValues;
   private final Optional<Transform> transform;
 
-  public AnnotationChangeRefactor(AnnotationMatcher fromType, String toType, Map<String, String> membersAndValuesToAdd, Set<String> namesForMembersToRemove, Map<String, String> memberNameUpdates, Map<String, String> memberNamesToUpdateWithNewValues, Optional<Transform> transform) {
+  public AnnotationChangeRefactor(AnnotationMatcher fromType, String toType, Map<String, String> membersAndValuesToAdd, Map<String,String> memberAndTypesToAdd, Set<String> namesForMembersToRemove, Map<String, String> memberNameUpdates, Map<String, String> memberNamesToUpdateWithNewValues, Optional<Transform> transform) {
     this.fromType = fromType;
     this.toType = toType;
     this.membersAndValuesToAdd = membersAndValuesToAdd;
+    this.membersAndTypesToAdd = memberAndTypesToAdd;
     this.namesForMembersToRemove = namesForMembersToRemove;
     this.memberNameUpdates = memberNameUpdates;
     this.memberNamesToUpdateWithNewValues = memberNamesToUpdateWithNewValues;
@@ -77,6 +80,7 @@ public class AnnotationChangeRefactor implements ASTOperation {
     private AnnotationMatcher fromType;
     private String toType;
     private Map<String, String> membersAndValuesToAdd = Map.of();
+    private Map<String, String> membersAndTypesToAdd = Map.of();
     private Set<String> namesForMembersToRemove = Set.of();
     private Map<String, String> memberNameUpdates = Map.of();
     private Optional<Transform> transform = Optional.empty();
@@ -99,6 +103,11 @@ public class AnnotationChangeRefactor implements ASTOperation {
 
     public Builder addMemberNameValuePairs(Map<String, String> membersAndValuesToAdd) {
       this.membersAndValuesToAdd = membersAndValuesToAdd;
+      return this;
+    }
+
+    public Builder addMemberNameTypePairs(Map<String, String> membersAndTypesToAdd) {
+      this.membersAndTypesToAdd = membersAndTypesToAdd;
       return this;
     }
 
@@ -126,6 +135,7 @@ public class AnnotationChangeRefactor implements ASTOperation {
       return new AnnotationChangeRefactor(fromType,
               toType,
               membersAndValuesToAdd,
+              membersAndTypesToAdd,
               namesForMembersToRemove,
               memberNameUpdates,
               memberNamesToUpdateWithNewValues,
@@ -199,14 +209,14 @@ public class AnnotationChangeRefactor implements ASTOperation {
 
 
   private Annotation addNewMembersToAnnotation(CompilationUnit compilationUnit, ASTRewrite rewriter, Annotation annotation) {
-    if (!membersAndValuesToAdd.isEmpty()) {
+    if (!membersAndValuesToAdd.isEmpty() || !membersAndTypesToAdd.isEmpty()) {
       final NormalAnnotation normalAnnotation;
       if (annotation.isMarkerAnnotation() || annotation.isSingleMemberAnnotation()) {
         normalAnnotation = convertAnnotationToNormalAnnotation(rewriter, annotation);
       } else {
         normalAnnotation = (NormalAnnotation) annotation;
       }
-      addMembersToNormalAnnotation(compilationUnit, rewriter, normalAnnotation, membersAndValuesToAdd);
+      addMembersToNormalAnnotation(compilationUnit, rewriter, normalAnnotation, membersAndValuesToAdd, membersAndTypesToAdd);
       return normalAnnotation;
     }
     return annotation;
@@ -332,16 +342,15 @@ public class AnnotationChangeRefactor implements ASTOperation {
   }
 
 
-  private void addMembersToNormalAnnotation(CompilationUnit compilationUnit, ASTRewrite rewriter, NormalAnnotation normalAnnotation, Map<String, String> membersAndValuesToAdd) {
+  private void addMembersToNormalAnnotation(CompilationUnit compilationUnit, ASTRewrite rewriter, NormalAnnotation normalAnnotation, Map<String, String> membersAndValuesToAdd, Map<String, String> membersAndTypesToAdd) {
     final ListRewrite listRewrite = rewriter.getListRewrite(normalAnnotation, NormalAnnotation.VALUES_PROPERTY);
     @SuppressWarnings("unchecked")
     List<MemberValuePair> originalMembers = listRewrite.getOriginalList();
     final List<String> originalMemberNames = originalMembers.stream().map(memberValuePair -> memberValuePair.getName().getIdentifier()).collect(Collectors.toList());
+
     membersAndValuesToAdd.forEach((memberName, value) -> {
       if(originalMemberNames.contains(memberName)) {
-        log.warn("A new member value pair with name " + memberName +
-                " was not added to annotation in this type " +  AstraUtils.getNameForCompilationUnit(compilationUnit) + " as it already exists. " +
-                "If you wish to overwrite the existing value, please configure the " + AnnotationChangeRefactor.class.getSimpleName() + "to update the value for an existing member name.");
+        logWarning(compilationUnit, memberName);
         return;
       }
       MemberValuePair newMemberAndValue = rewriter.getAST().newMemberValuePair();
@@ -351,5 +360,33 @@ public class AnnotationChangeRefactor implements ASTOperation {
       newMemberAndValue.setValue(valueLiteral);
       listRewrite.insertLast(newMemberAndValue, null);
     });
+
+    membersAndTypesToAdd.forEach((memberName, value) -> {
+      if(originalMemberNames.contains(memberName)) {
+        logWarning(compilationUnit, memberName);
+        return;
+      }
+      MemberValuePair newMemberAndValue = rewriter.getAST().newMemberValuePair();
+      newMemberAndValue.setName(rewriter.getAST().newSimpleName(memberName));
+      final TypeLiteral typeLiteral = rewriter.getAST().newTypeLiteral();
+
+      // Handle both qualified and simple types
+      if (value.contains(".")) {
+        String[] qualifiedName = value.split("\\.");
+        typeLiteral.setType(rewriter.getAST().newNameQualifiedType(rewriter.getAST().newName(qualifiedName[0]), rewriter.getAST().newSimpleName(qualifiedName[1])));
+      } else {
+        typeLiteral.setType(rewriter.getAST().newSimpleType(rewriter.getAST().newSimpleName(value)));
+      }
+
+      newMemberAndValue.setValue(typeLiteral);
+      listRewrite.insertLast(newMemberAndValue, null);
+    });
+  }
+
+
+  private static void logWarning(CompilationUnit compilationUnit, String memberName) {
+    log.warn("A new member value pair with name " + memberName +
+            " was not added to annotation in this type " +  AstraUtils.getNameForCompilationUnit(compilationUnit) + " as it already exists. " +
+            "If you wish to overwrite the existing value, please configure the " + AnnotationChangeRefactor.class.getSimpleName() + "to update the value for an existing member name.");
   }
 }

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/TestAnnotationsRefactor.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/TestAnnotationsRefactor.java
@@ -16,10 +16,13 @@ import org.alfasoftware.astra.exampleTypes.AnnotationA;
 import org.alfasoftware.astra.exampleTypes.AnnotationB;
 import org.alfasoftware.astra.exampleTypes.AnnotationC;
 import org.alfasoftware.astra.exampleTypes.AnnotationD;
+import org.alfasoftware.astra.exampleTypes.AnnotationE;
 import org.alfasoftware.astra.exampleTypes.B.InnerAnnotationB;
 import org.eclipse.jdt.core.dom.Annotation;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.junit.Test;
+
+import static org.alfasoftware.astra.core.utils.AstraUtils.addImport;
 
 public class TestAnnotationsRefactor extends AbstractRefactorTest {
 
@@ -218,6 +221,28 @@ public class TestAnnotationsRefactor extends AbstractRefactorTest {
               .updateMembersWithNameToValue(Map.of("value", "\"BAR\""))
               .build()
       )));
+  }
+
+
+  /**
+   * Example covers:
+   * - updating the member of an annotation with a simple type literal
+   * - updating the member of an annotation with a qualified type literal
+   */
+  @Test
+  public void testUpdateMemberType() {
+    assertRefactor(
+            UpdateMemberTypeInAnnotationExample.class,
+            new HashSet<>(Arrays.asList(
+                    AnnotationChangeRefactor.builder()
+                            .from(AnnotationMatcher.builder()
+                                    .withFullyQualifiedName(AnnotationE.class.getName())
+                                    .build())
+                            .to(AnnotationE.class.getName())
+                            .addMemberNameTypePairs(Map.of("type", "Integer", "anotherType", "WithNestedClass.NestedClass"))
+                            .withTransform((cu, a, rw) -> addImport(cu, "org.alfasoftware.astra.exampleTypes.WithNestedClass", rw))
+                            .build()
+            )));
   }
 
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/UpdateMemberTypeInAnnotationExample.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/UpdateMemberTypeInAnnotationExample.java
@@ -1,0 +1,13 @@
+package org.alfasoftware.astra.core.refactoring.annotations;
+
+import org.alfasoftware.astra.exampleTypes.AnnotationE;
+
+public class UpdateMemberTypeInAnnotationExample {
+
+  @AnnotationE
+  protected long someField;
+
+  @AnnotationE(value = "A string of no importance")
+  protected String anotherField;
+}
+

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/UpdateMemberTypeInAnnotationExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/UpdateMemberTypeInAnnotationExampleAfter.java
@@ -5,10 +5,10 @@ import org.alfasoftware.astra.exampleTypes.WithNestedClass;
 
 public class UpdateMemberTypeInAnnotationExampleAfter {
 
-  @AnnotationE(type = Integer.class, anotherType = WithNestedClass.NestedClass.class)
+  @AnnotationE(anotherType = WithNestedClass.NestedClass.class, type = Integer.class)
   protected long someField;
 
-  @AnnotationE(value = "A string of no importance", type = Integer.class, anotherType = WithNestedClass.NestedClass.class)
+  @AnnotationE(value = "A string of no importance", anotherType = WithNestedClass.NestedClass.class, type = Integer.class)
   protected String anotherField;
 }
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/UpdateMemberTypeInAnnotationExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/UpdateMemberTypeInAnnotationExampleAfter.java
@@ -1,0 +1,14 @@
+package org.alfasoftware.astra.core.refactoring.annotations;
+
+import org.alfasoftware.astra.exampleTypes.AnnotationE;
+import org.alfasoftware.astra.exampleTypes.WithNestedClass;
+
+public class UpdateMemberTypeInAnnotationExampleAfter {
+
+  @AnnotationE(type = Integer.class, anotherType = WithNestedClass.NestedClass.class)
+  protected long someField;
+
+  @AnnotationE(value = "A string of no importance", type = Integer.class, anotherType = WithNestedClass.NestedClass.class)
+  protected String anotherField;
+}
+

--- a/astra-core/src/test/java/org/alfasoftware/astra/exampleTypes/AnnotationE.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/exampleTypes/AnnotationE.java
@@ -1,0 +1,11 @@
+package org.alfasoftware.astra.exampleTypes;
+
+public @interface AnnotationE {
+
+  String value() default "";
+
+  Class<?> type() default void.class;
+
+  Class<?> anotherType() default void.class;
+}
+

--- a/astra-core/src/test/java/org/alfasoftware/astra/exampleTypes/WithNestedClass.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/exampleTypes/WithNestedClass.java
@@ -1,0 +1,6 @@
+package org.alfasoftware.astra.exampleTypes;
+
+public class WithNestedClass {
+
+   public static class NestedClass {}
+}


### PR DESCRIPTION
Added ability to update annotation members with type literals, both qualified and unqualified.