### PR TITLE
Add missing goalprefix for plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,9 @@
         <plugin>
           <artifactId>maven-plugin-plugin</artifactId>
           <version>${maven-plugin-plugin.version}</version>
+          <configuration>
+            <goalPrefix>astra</goalPrefix>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>  


### PR DESCRIPTION
Makes it easier to use the plugin from the command line i.e. `mvn astra:2.4.x:refactor -Dastra.usecase=com.example.MyUseCase`