### PR TITLE
Ignore additional classpath on usecase when using the plugin

### DIFF
--- a/astra-maven-plugin/src/main/java/org/alfasoftware/astra/RefactorMojo.java
+++ b/astra-maven-plugin/src/main/java/org/alfasoftware/astra/RefactorMojo.java
@@ -84,7 +84,9 @@ public class RefactorMojo extends AbstractMojo {
 
       @Override
       public Set<String> getAdditionalClassPathEntries() {
+        // This is a Maven plugin that can access the full classpath required for the source code Astra is running over - no additional help required.
         return Set.of();
+
       }
     });
 

--- a/astra-maven-plugin/src/main/java/org/alfasoftware/astra/RefactorMojo.java
+++ b/astra-maven-plugin/src/main/java/org/alfasoftware/astra/RefactorMojo.java
@@ -59,17 +59,15 @@ public class RefactorMojo extends AbstractMojo {
   @Override
   public void execute() throws MojoExecutionException {
 
-	List<String> testClasspathElements;
-	try {
+    List<String> testClasspathElements;
+    try {
 	    testClasspathElements = project.getTestClasspathElements();
     } catch (DependencyResolutionRequiredException e) {
       throw new MojoExecutionException("Unable to resolve test class path for the project", e);
     }
 
-    // remove anything within this projects target directory as it has been
+    // remove anything within this projects target directory as this will invalidate it
     testClasspathElements.removeIf(s -> s.startsWith(targetDirectory));
-  
-    // might need to add source from other projects if running multi-module??
   
     UseCase useCaseInstance = getUseCaseInstance();
     AstraCore.run(sourceDirectory.getAbsolutePath(), new UseCase() {
@@ -86,9 +84,7 @@ public class RefactorMojo extends AbstractMojo {
 
       @Override
       public Set<String> getAdditionalClassPathEntries() {
-        HashSet<String> additionalClassPath = new HashSet<>(useCaseInstance.getAdditionalClassPathEntries());
-        additionalClassPath.addAll(testClasspathElements);
-        return additionalClassPath;
+        return Set.of();
       }
     });
 


### PR DESCRIPTION
It is not appropriate for the plugin to assume that an arbitrary classpath will be present (particularly if used in CI-type pipelines). In order for the before refactor classes to compile the classpath will already need to include the class path. If the 'after' classpath needs to be different either the project pom can be amended upfront or else the plugin can be declared with additional dependencies.