### PR TITLE
Improvement to annotation refactor 

### DIFF
--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/AnnotationChangeSameSimpleNameExample.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/AnnotationChangeSameSimpleNameExample.java
@@ -1,0 +1,15 @@
+package org.alfasoftware.astra.core.refactoring.annotations;
+
+import org.alfasoftware.astra.exampleTypes.AnnotationA;
+
+@AnnotationA("")
+public class AnnotationChangeSameSimpleNameExample {
+
+    @AnnotationA(value="A")
+    protected long someField;
+
+    @AnnotationA("BAR")
+    public char getBar(){
+        return 'a';
+    }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/AnnotationChangeSameSimpleNameExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/AnnotationChangeSameSimpleNameExampleAfter.java
@@ -1,0 +1,15 @@
+package org.alfasoftware.astra.core.refactoring.annotations;
+
+import org.alfasoftware.astra.moreexampletypes.AnnotationA;
+
+@AnnotationA("")
+public class AnnotationChangeSameSimpleNameExampleAfter {
+
+    @AnnotationA(value="A")
+    protected long someField;
+
+    @AnnotationA("BAR")
+    public char getBar(){
+        return 'a';
+    }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/AnnotationChangeSameSimpleNameWithRemainderExample.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/AnnotationChangeSameSimpleNameWithRemainderExample.java
@@ -1,0 +1,18 @@
+package org.alfasoftware.astra.core.refactoring.annotations;
+
+import org.alfasoftware.astra.exampleTypes.AnnotationA;
+
+@AnnotationA("")
+public class AnnotationChangeSameSimpleNameWithRemainderExample {
+
+    /**
+     * This annotation should not change
+     */
+    @AnnotationA(value="A")
+    protected long someField;
+
+    @AnnotationA("BAR")
+    public char getBar(){
+        return 'a';
+    }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/AnnotationChangeSameSimpleNameWithRemainderExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/AnnotationChangeSameSimpleNameWithRemainderExampleAfter.java
@@ -1,0 +1,18 @@
+package org.alfasoftware.astra.core.refactoring.annotations;
+
+import org.alfasoftware.astra.exampleTypes.AnnotationA;
+
+@org.alfasoftware.astra.moreexampletypes.AnnotationA("")
+public class AnnotationChangeSameSimpleNameWithRemainderExampleAfter {
+
+    /**
+     * This annotation should not change
+     */
+    @AnnotationA(value="A")
+    protected long someField;
+
+    @org.alfasoftware.astra.moreexampletypes.AnnotationA("BAR")
+    public char getBar(){
+        return 'a';
+    }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/TestAnnotationsRefactor.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/TestAnnotationsRefactor.java
@@ -1,5 +1,7 @@
 package org.alfasoftware.astra.core.refactoring.annotations;
 
+import static org.alfasoftware.astra.core.utils.AstraUtils.addImport;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
@@ -22,7 +24,13 @@ import org.eclipse.jdt.core.dom.Annotation;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.junit.Test;
 
-import static org.alfasoftware.astra.core.utils.AstraUtils.addImport;
+/**
+ * TODO TestAnnotationsRefactor class-level Javadoc.
+ *
+ * <p>...</p>
+ *
+ * @author Copyright (c) Alfa Financial Software Limited. 2025
+ */
 
 public class TestAnnotationsRefactor extends AbstractRefactorTest {
 
@@ -88,6 +96,60 @@ public class TestAnnotationsRefactor extends AbstractRefactorTest {
             .withValue("BAR")
             .build())
           .to(AnnotationB.class.getTypeName()).build()
+      )));
+  }
+
+  @Test
+  public void testSameSimpleNameAnnotationChange() {
+    assertRefactor(
+      AnnotationChangeSameSimpleNameExample.class,
+      new HashSet<>(Arrays.asList(
+        AnnotationChangeRefactor.builder()
+          .from(AnnotationMatcher.builder()
+            .withFullyQualifiedName(AnnotationA.class.getName())
+            .withValue("")
+            .build())
+          .to(org.alfasoftware.astra.moreexampletypes.AnnotationA.class.getTypeName()).build(),
+        AnnotationChangeRefactor.builder()
+          .from(AnnotationMatcher.builder()
+            .withFullyQualifiedName(AnnotationA.class.getName())
+            .withValue("A")
+            .build())
+          .to(org.alfasoftware.astra.moreexampletypes.AnnotationA.class.getTypeName()).build(),
+        AnnotationChangeRefactor.builder()
+          .from(AnnotationMatcher.builder()
+            .withFullyQualifiedName(AnnotationA.class.getName())
+            .withValue("BAR")
+            .build())
+          .to(org.alfasoftware.astra.moreexampletypes.AnnotationA.class.getTypeName()).build()
+      )));
+  }
+
+  /**
+   * Example where we are not swapping over all instances of an annotation with the same simple name
+   * therefore we force the new annotation to be fully qualified.
+   */
+  @Test
+  public void testSameSimpleNameAnnotationChangeWithRemainder() {
+    assertRefactor(
+      AnnotationChangeSameSimpleNameWithRemainderExample.class,
+      new HashSet<>(Arrays.asList(
+        AnnotationChangeRefactor.builder()
+          .from(AnnotationMatcher.builder()
+            .withFullyQualifiedName(AnnotationA.class.getName())
+            .withValue("")
+            .build())
+          .to(org.alfasoftware.astra.moreexampletypes.AnnotationA.class.getTypeName())
+          .forceQualifiedName()
+          .build(),
+        AnnotationChangeRefactor.builder()
+          .from(AnnotationMatcher.builder()
+            .withFullyQualifiedName(AnnotationA.class.getName())
+            .withValue("BAR")
+            .build())
+          .to(org.alfasoftware.astra.moreexampletypes.AnnotationA.class.getTypeName())
+          .forceQualifiedName()
+          .build()
       )));
   }
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/TestAnnotationsRefactor.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/annotations/TestAnnotationsRefactor.java
@@ -24,14 +24,6 @@ import org.eclipse.jdt.core.dom.Annotation;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.junit.Test;
 
-/**
- * TODO TestAnnotationsRefactor class-level Javadoc.
- *
- * <p>...</p>
- *
- * @author Copyright (c) Alfa Financial Software Limited. 2025
- */
-
 public class TestAnnotationsRefactor extends AbstractRefactorTest {
 
   @Test

--- a/astra-core/src/test/java/org/alfasoftware/astra/moreexampletypes/AnnotationA.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/moreexampletypes/AnnotationA.java
@@ -1,0 +1,9 @@
+package org.alfasoftware.astra.moreexampletypes;
+
+public @interface AnnotationA {
+
+  String value() default "";
+
+  String othervalue() default "";
+}
+


### PR DESCRIPTION
Allow the force use of a fully qualified name in cases where we aren't replacing all uses of an annotation.
Otherwise make sure we always replace the import.