### PR TITLE
Publish directly to Maven Central and fix GPG issue

### DIFF
--- a/.maven-settings.xml
+++ b/.maven-settings.xml
@@ -1,7 +1,7 @@
 <settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/SETTINGS/1.0.0" xsi:schemalocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-      <id>ossrh</id>
+      <id>central</id>
       <username>${env.SONATYPE_USERNAME}</username>
       <password>${env.SONATYPE_PASSWORD}</password>
     </server>
@@ -9,7 +9,7 @@
 
   <profiles>
     <profile>
-      <id>ossrh</id>
+      <id>central</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+dist: noble
+jdk: openjdk21
 jobs:
   include:
    - if: repo = alfasoftware/astra AND head_repo = alfasoftware/astra AND type = pull_request
@@ -9,6 +11,6 @@ jobs:
    - if: repo = alfasoftware/astra AND (branch = main OR tag IS present) AND NOT type = pull_request
      name: "Deploy"
      script:
-        - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import
-        - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust
+        - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --batch --import
+        - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --batch --import-ownertrust
         - mvn clean deploy --settings .maven-settings.xml -B -U -Prelease

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <maven-plugin-annotations.version>3.11.0</maven-plugin-annotations.version>
     <maven-plugin-plugin.version>3.12.0</maven-plugin-plugin.version>
-    <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
+    <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
     
     <!-- maven version for plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <maven-plugin-annotations.version>3.11.0</maven-plugin-annotations.version>
     <maven-plugin-plugin.version>3.12.0</maven-plugin-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
-    <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+    <sonatype-central-publishing-plugin.version>0.8.0</sonatype-central-publishing-plugin.version>
     
     <!-- maven version for plugin -->
     <maven.baseVersion>3.8.2</maven.baseVersion>
@@ -260,7 +260,7 @@
           <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.8.0</version>
+            <version>${sonatype-central-publishing-plugin.version}</version>
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>

--- a/pom.xml
+++ b/pom.xml
@@ -258,14 +258,13 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
             </configuration>
           </plugin>
           <plugin>
@@ -296,15 +295,5 @@
     <url>https://github.com/alfasoftware/astra</url>
     <tag>HEAD</tag>
   </scm>
-  
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
+
 </project>


### PR DESCRIPTION
Astra used to publish to OSSRH which [has been sunsetted](https://central.sonatype.org/news/20250326_ossrh_sunset/#announcement-of-the-end-of-life-sunset-date-for-ossrh).

This change moves Astra to publishing directly to Maven Central using Sonatype's publishing portal plugin.

It also moves the Travis build on to Ubuntu 24.04 and OpenJDK 21, resolving an issue with JAR signing via GPG.