### PR TITLE
Remove redundant java.home classpath entry from UseCase

### DIFF
--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/UseCase.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/UseCase.java
@@ -1,7 +1,5 @@
 package org.alfasoftware.astra.core.refactoring;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -39,17 +37,12 @@ public interface UseCase {
     return new HashSet<>();
   }
 
-  static final String JAVA_PATH = System.getProperty("java.home"); // The JRE
-  static final Set<String> DEFAULT_CLASSPATH_ENTRIES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(JAVA_PATH)));
-
   /**
    * @return The absolute classpaths required to resolve types and bindings when running the ASTOperations specified in this use case.
+   *         The running VM's boot classpath is included automatically by the parser.
    */
   default String[] getClassPath() {
-    Set<String> classPath = new HashSet<>();
-    classPath.addAll(DEFAULT_CLASSPATH_ENTRIES);
-    classPath.addAll(getAdditionalClassPathEntries());
-    return classPath.toArray(new String[0]);
+    return getAdditionalClassPathEntries().toArray(new String[0]);
   }
 
   /**

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/analysis/AbstractAnalysisTest.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/analysis/AbstractAnalysisTest.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 
 import org.alfasoftware.astra.core.analysis.operations.AnalysisOperation;
 import org.alfasoftware.astra.core.analysis.operations.AnalysisResult;
-import org.alfasoftware.astra.core.refactoring.UseCase;
 import org.alfasoftware.astra.core.utils.AstraCore;
 import org.eclipse.jface.text.BadLocationException;
 
@@ -36,8 +35,7 @@ public abstract class AbstractAnalysisTest {
    * @param expectedResults The collection of expected analysis results for the example file
    */
   protected <T extends AnalysisResult> void assertAnalysis(Class<?> fileToAnalyse, AnalysisOperation<T> analysisOperation, Collection<T> expectedResults) {
-    // This just gets the java path.
-    assertAnalysisWithClassPath(fileToAnalyse, analysisOperation, expectedResults, UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
+    assertAnalysisWithClassPath(fileToAnalyse, analysisOperation, expectedResults, new String[0]);
   }
 
   protected <T extends AnalysisResult> void assertAnalysisWithClassPath(Class<?> fileToAnalyse, AnalysisOperation<T> analysisOperation, Collection<T> expectedResults, String[] classPath) {

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestAnnotationMatcher.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestAnnotationMatcher.java
@@ -4,7 +4,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import org.alfasoftware.astra.core.refactoring.UseCase;
 import org.alfasoftware.astra.core.utils.AstraUtils;
 import org.alfasoftware.astra.core.utils.ClassVisitor;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -222,7 +221,7 @@ public class TestAnnotationMatcher {
   }
 
   private ClassVisitor parse(String source) {
-    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(Path.of(""), source, new String[]{TEST_SOURCE}, UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
+    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(Path.of(""), source, new String[]{TEST_SOURCE}, new String[0]);
     ClassVisitor visitor = new ClassVisitor();
     compilationUnit.accept(visitor);
     return visitor;

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestMethodMatcher.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestMethodMatcher.java
@@ -12,7 +12,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.alfasoftware.astra.core.refactoring.UseCase;
 import org.alfasoftware.astra.core.utils.AstraUtils;
 import org.alfasoftware.astra.core.utils.ClassVisitor;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
@@ -317,7 +316,7 @@ public class TestMethodMatcher {
       fail("IOException when reading file : " + e);
     }
 
-    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(Path.of(""), fileContentBefore, new String[]{TEST_SOURCE}, UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
+    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(Path.of(""), fileContentBefore, new String[]{TEST_SOURCE}, new String[0]);
 
     final ClassVisitor visitor = new ClassVisitor();
     compilationUnit.accept(visitor);

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestTypeMatcher.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestTypeMatcher.java
@@ -10,7 +10,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.alfasoftware.astra.core.refactoring.UseCase;
 import org.alfasoftware.astra.core.utils.AstraUtils;
 import org.alfasoftware.astra.core.utils.ClassVisitor;
 import org.alfasoftware.astra.exampleTypes.A;
@@ -724,7 +723,7 @@ public class TestTypeMatcher {
 
 
   private ClassVisitor parse(String source) {
-    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(Path.of(""), source, new String[]{TEST_SOURCE}, UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
+    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(Path.of(""), source, new String[]{TEST_SOURCE}, new String[0]);
     ClassVisitor visitor = new ClassVisitor();
     compilationUnit.accept(visitor);
     return visitor;

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/AbstractRefactorTest.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/AbstractRefactorTest.java
@@ -29,8 +29,7 @@ public abstract class AbstractRefactorTest {
    * @param refactors Set of refactors to apply
    */
   protected void assertRefactor(Class<?> beforeClass, Set<? extends ASTOperation> refactors) {
-    // This just gets the java path.
-    assertRefactorWithClassPath(beforeClass, refactors, UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
+    assertRefactorWithClassPath(beforeClass, refactors, new String[0]);
   }
 
   protected void assertRefactorWithClassPath(Class<?> beforeClass, Set<? extends ASTOperation> refactors, String[] classPath) {

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TestUpdateTypeRefactor.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TestUpdateTypeRefactor.java
@@ -12,7 +12,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.alfasoftware.astra.core.refactoring.AbstractRefactorTest;
-import org.alfasoftware.astra.core.refactoring.UseCase;
 import org.alfasoftware.astra.core.refactoring.operations.types.UpdateTypeRefactor;
 import org.alfasoftware.astra.core.refactoring.types.newpackage.UpdatedTypeExampleAfter;
 import org.alfasoftware.astra.core.utils.ASTOperation;
@@ -67,7 +66,7 @@ public class TestUpdateTypeRefactor extends AbstractRefactorTest {
           fileContentBefore,
           operations,
           new HashSet<>(Arrays.asList(TEST_SOURCE)).toArray(new String[0]),
-          UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0])
+          new String[0]
       );
 
       expectedBefore = changesToApplyToBefore.apply(expectedBefore);

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/utils/TestAstraUtils.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/utils/TestAstraUtils.java
@@ -175,7 +175,7 @@ public class TestAstraUtils {
     }
 
     CompilationUnit buildCompilationUnit() {
-      return AstraUtils.readAsCompilationUnit(before, source, new String[]{SOURCE, TEST_SOURCE}, UseCase.DEFAULT_CLASSPATH_ENTRIES.toArray(new String[0]));
+      return AstraUtils.readAsCompilationUnit(before, source, new String[]{SOURCE, TEST_SOURCE}, new String[0]);
     }
   }
 


### PR DESCRIPTION
UseCase.DEFAULT_CLASSPATH_ENTRIES added java.home to the classpath passed to the JDT ASTParser. This was already unnecessary because AstraUtils.createParser() calls setEnvironment() with includeRunningVMBootclasspath=true, which makes JDT automatically include the running VM''s boot classpath.

On Java 9+ the value of java.home has changed: it now points to the JDK root directory rather than a jre/ subdirectory containing rt.jar. Passing it as a classpath entry has no effect at best and can trigger spurious warnings at worst.

Remove JAVA_PATH and DEFAULT_CLASSPATH_ENTRIES from UseCase, simplify getClassPath() to delegate directly to getAdditionalClassPathEntries(), and update all test callsites that referenced DEFAULT_CLASSPATH_ENTRIES.