### PR TITLE
Add parallel file processing to AstraCore

### DIFF
--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/UseCase.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/UseCase.java
@@ -51,4 +51,13 @@ public interface UseCase {
   default String[] getSources() {
     return new String[] { "" };
   }
+
+  /**
+   * @return The number of threads to use when processing files in parallel.
+   *         Defaults to {@link Runtime#availableProcessors()}.
+   *         Override and return {@code 1} to force sequential processing.
+   */
+  default int getParallelism() {
+    return Runtime.getRuntime().availableProcessors();
+  }
 }

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/utils/AstraCore.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/utils/AstraCore.java
@@ -10,10 +10,15 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
@@ -58,7 +63,7 @@ public class AstraCore {
       AstraCore main = new AstraCore();
       main.runOperations(targetDirectoryPath, useCase, sources, classPath);
     } catch (IOException e) {
-      log.error("ioE: " + e);
+      throw new RuntimeException("Astra run failed for directory [" + targetDirectoryPath + "]: " + e.getMessage(), e);
     }
   }
 
@@ -95,19 +100,54 @@ public class AstraCore {
         .collect(Collectors.toList());
     log.info(filteredJavaFiles.size() + " files remain after prefiltering");
 
-    Set<? extends ASTOperation> operations = useCase.getOperations();
+    if (filteredJavaFiles.isEmpty()) {
+      log.info(getPrintableDuration(Duration.between(startTime, Instant.now())));
+      return;
+    }
 
-    for (Path f : filteredJavaFiles) {
-      // TODO Naively we can multi-thread here (i.e. per file) but simple testing indicated that this slowed us down.
-      applyOperationsAndSave(f, operations, sources, classPath);
-      long newPercentage = currentFileIndex.incrementAndGet() * 100 / filteredJavaFiles.size();
-      if (newPercentage != currentPercentage.get()) {
-        currentPercentage.set(newPercentage);
-        logProgress(currentFileIndex.get(), currentPercentage.get(), startTime, filteredJavaFiles.size());
+    Set<? extends ASTOperation> operations = useCase.getOperations();
+    int parallelism = useCase.getParallelism();
+    log.info("Processing [" + filteredJavaFiles.size() + "] files with [" + parallelism + "] thread(s)");
+
+    List<Throwable> fileErrors = new ArrayList<>();
+    ExecutorService executor = Executors.newFixedThreadPool(parallelism);
+    try {
+      List<Future<?>> futures = filteredJavaFiles.stream()
+          .map(f -> executor.submit(() -> applyOperationsAndSave(f, operations, sources, classPath)))
+          .collect(Collectors.toList());
+
+      for (Future<?> future : futures) {
+        try {
+          future.get();
+        } catch (ExecutionException e) {
+          Throwable cause = e.getCause();
+          log.error("Failed to process file: " + cause.getMessage(), cause);
+          fileErrors.add(cause);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException("File processing was interrupted", e);
+        }
+        long idx = currentFileIndex.incrementAndGet();
+        long newPct = idx * 100 / filteredJavaFiles.size();
+        if (currentPercentage.getAndSet(newPct) != newPct) {
+          logProgress(idx, newPct, startTime, filteredJavaFiles.size());
+        }
+      }
+    } finally {
+      List<Runnable> notStarted = executor.shutdownNow();
+      if (!notStarted.isEmpty()) {
+        log.warn(notStarted.size() + " file(s) were not processed due to early termination");
       }
     }
 
     log.info(getPrintableDuration(Duration.between(startTime, Instant.now())));
+
+    if (!fileErrors.isEmpty()) {
+      IOException summary = new IOException(
+          fileErrors.size() + " file(s) failed during processing; see suppressed exceptions for details");
+      fileErrors.forEach(summary::addSuppressed);
+      throw summary;
+    }
   }
 
 
@@ -185,12 +225,8 @@ public class AstraCore {
         // save the file (over the original)
         Files.write(javaFile.toAbsolutePath(), fileContentAfter.getBytes(), StandardOpenOption.TRUNCATE_EXISTING);
       }
-    } catch (IOException e) {
-      log.error("ioE: " + e);
-    } catch (BadLocationException e) {
-      log.error("blE: " + e);
-    } catch (IllegalArgumentException e) {
-      log.error("IAE: " + e);
+    } catch (IOException | BadLocationException | IllegalArgumentException e) {
+      throw new RuntimeException("Failed to process file [" + javaFile + "]: " + e.getMessage(), e);
     }
   }
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/utils/TestAstraCoreParallelExecution.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/utils/TestAstraCoreParallelExecution.java
@@ -1,0 +1,196 @@
+package org.alfasoftware.astra.core.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.alfasoftware.astra.core.refactoring.UseCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestAstraCoreParallelExecution {
+
+  private Path tempDir;
+
+  @Before
+  public void setUp() throws IOException {
+    tempDir = Files.createTempDirectory("astra-parallel-test");
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    Files.walk(tempDir)
+        .sorted(Comparator.reverseOrder())
+        .forEach(path -> path.toFile().delete());
+  }
+
+  @Test
+  public void testDefaultParallelismMatchesAvailableProcessors() {
+    UseCase useCase = () -> new HashSet<>();
+    assertEquals(Runtime.getRuntime().availableProcessors(), useCase.getParallelism());
+  }
+
+  /**
+   * Verifies that all files in the target directory are visited when running with parallelism > 1.
+   * Each file should have its compilation unit passed to the operation at least once.
+   */
+  @Test
+  public void testParallelExecutionProcessesAllFiles() throws IOException {
+    int fileCount = 4;
+    for (int i = 1; i <= fileCount; i++) {
+      Files.writeString(tempDir.resolve("File" + i + ".java"),
+          "public class File" + i + " { void method() {} }");
+    }
+
+    Set<Path> processedFiles = ConcurrentHashMap.newKeySet();
+
+    UseCase useCase = new UseCase() {
+      @Override
+      public Set<? extends ASTOperation> getOperations() {
+        return Set.of((compilationUnit, node, rewriter) -> {
+          Path path = (Path) compilationUnit.getProperty(CompilationUnitProperty.ABSOLUTE_PATH);
+          if (path != null) {
+            processedFiles.add(path);
+          }
+        });
+      }
+
+      @Override
+      public int getParallelism() {
+        return fileCount;
+      }
+    };
+
+    AstraCore.run(tempDir.toString(), useCase);
+
+    assertEquals("All files should have been visited", fileCount, processedFiles.size());
+  }
+
+  /**
+   * Verifies that sequential (parallelism=1) and parallel (parallelism=N) execution
+   * visit the same number of unique files.
+   */
+  @Test
+  public void testParallelAndSequentialVisitSameFiles() throws IOException {
+    int fileCount = 3;
+    for (int i = 1; i <= fileCount; i++) {
+      Files.writeString(tempDir.resolve("ClassFile" + i + ".java"),
+          "public class ClassFile" + i + " {}");
+    }
+
+    for (int parallelism : new int[]{1, fileCount}) {
+      Set<Path> visited = ConcurrentHashMap.newKeySet();
+      UseCase useCase = new UseCase() {
+        @Override
+        public Set<? extends ASTOperation> getOperations() {
+          return Set.of((compilationUnit, node, rewriter) -> {
+            Path path = (Path) compilationUnit.getProperty(CompilationUnitProperty.ABSOLUTE_PATH);
+            if (path != null) visited.add(path);
+          });
+        }
+
+        @Override
+        public int getParallelism() {
+          return parallelism;
+        }
+      };
+
+      AstraCore.run(tempDir.toString(), useCase);
+      assertEquals("parallelism=" + parallelism + " should visit all files", fileCount, visited.size());
+    }
+  }
+
+  /**
+   * Verifies that per-file errors are surfaced rather than silently swallowed.
+   * An operation that always throws should cause AstraCore.run() to throw.
+   */
+  @Test
+  public void testParallelExecutionSurfacesPerFileErrors() throws IOException {
+    Files.writeString(tempDir.resolve("File1.java"), "public class File1 {}");
+    Files.writeString(tempDir.resolve("File2.java"), "public class File2 {}");
+
+    UseCase useCase = new UseCase() {
+      @Override
+      public Set<? extends ASTOperation> getOperations() {
+        return Set.of((compilationUnit, node, rewriter) -> {
+          throw new RuntimeException("Intentional test failure");
+        });
+      }
+
+      @Override
+      public int getParallelism() {
+        return 2;
+      }
+    };
+
+    try {
+      AstraCore.run(tempDir.toString(), useCase);
+      fail("Expected a RuntimeException to be thrown for failing operations");
+    } catch (RuntimeException e) {
+      assertNotNull("Exception message should be present", e.getMessage());
+      // The root cause chain should reach the original failures
+      Throwable root = e;
+      while (root.getCause() != null) {
+        root = root.getCause();
+      }
+      assertTrue("Exception chain should reference processing failures",
+          root.getMessage() != null);
+    }
+  }
+
+  /**
+   * Verifies that a single failing file does not prevent other files from being processed.
+   */
+  @Test
+  public void testParallelExecutionContinuesAfterFileError() throws IOException {
+    int totalFiles = 4;
+    for (int i = 1; i <= totalFiles; i++) {
+      Files.writeString(tempDir.resolve("File" + i + ".java"),
+          "public class File" + i + " {}");
+    }
+
+    Set<Path> processedFiles = ConcurrentHashMap.newKeySet();
+    AtomicInteger failCount = new AtomicInteger();
+
+    UseCase useCase = new UseCase() {
+      @Override
+      public Set<? extends ASTOperation> getOperations() {
+        return Set.of((compilationUnit, node, rewriter) -> {
+          Path path = (Path) compilationUnit.getProperty(CompilationUnitProperty.ABSOLUTE_PATH);
+          if (path != null && path.getFileName().toString().equals("File2.java")) {
+            failCount.incrementAndGet();
+            throw new RuntimeException("Intentional failure for File2");
+          }
+          if (path != null) {
+            processedFiles.add(path);
+          }
+        });
+      }
+
+      @Override
+      public int getParallelism() {
+        return 2;
+      }
+    };
+
+    try {
+      AstraCore.run(tempDir.toString(), useCase);
+      fail("Expected a RuntimeException due to File2 failing");
+    } catch (RuntimeException e) {
+      // File2 failed, so 3 other files should have been processed successfully
+      assertEquals("Non-failing files should have been processed", totalFiles - 1, processedFiles.size());
+      assertTrue("File2 should have triggered the failure", failCount.get() > 0);
+    }
+  }
+}


### PR DESCRIPTION
- Add UseCase#getParallelism() (defaults to availableProcessors()) so callers can control the thread-pool size, or pass 1 for sequential processing.
- Replace the sequential for loop in AstraCore#runOperations with a fixed ExecutorService thread pool. Each file gets its own CompilationUnit and ASTRewrite so no file-level state is shared between threads.
- Fix silent error swallowing in applyOperationsAndSave: checked exceptions are now re-thrown as RuntimeException so failures propagate to the caller.
- Collect per-file failures across all threads; after all files finish, surface them together as an IOException with each cause attached as a suppressed exception.
- Fix run() swallowing the final IOException instead of propagating it.
- Guard against division-by-zero in progress logging when the filtered file list is empty.
- Add TestAstraCoreParallelExecution covering: default parallelism, all files visited with parallelism>1, sequential vs parallel visit same files, errors surfaced not swallowed, processing continues past a single failing file.