### PR TITLE
Migrate logging from Log4j 1.x to SLF4J + Logback

### DIFF
--- a/astra-cli/src/main/java/org/alfasoftware/astracli/commandline/AstraChangeType.java
+++ b/astra-cli/src/main/java/org/alfasoftware/astracli/commandline/AstraChangeType.java
@@ -10,7 +10,8 @@ import org.alfasoftware.astra.core.refactoring.UseCase;
 import org.alfasoftware.astra.core.refactoring.operations.types.TypeReferenceRefactor;
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraCore;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
@@ -23,7 +24,7 @@ import picocli.CommandLine.Option;
 )
 class AstraChangeType implements Runnable {
 	
-	private static final Logger log = Logger.getLogger(AstraChangeType.class);
+	private static final Logger log = LoggerFactory.getLogger(AstraChangeType.class);
 
   @CommandLine.Parameters(
     arity = "2",

--- a/astra-cli/src/main/java/org/alfasoftware/astracli/commandline/AstraMethodInvocation.java
+++ b/astra-cli/src/main/java/org/alfasoftware/astracli/commandline/AstraMethodInvocation.java
@@ -14,7 +14,8 @@ import org.alfasoftware.astra.core.refactoring.UseCase;
 import org.alfasoftware.astra.core.refactoring.operations.methods.MethodInvocationRefactor;
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraCore;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
 
@@ -29,7 +30,7 @@ import picocli.CommandLine;
         description = "Finds method invocations matching given criteria, and performs a refactoring.")
 class AstraMethodInvocation implements Runnable {
 
-	private static final Logger log = Logger.getLogger(AstraMethodInvocation.class);
+	private static final Logger log = LoggerFactory.getLogger(AstraMethodInvocation.class);
 
     @CommandLine.Option(
       names = {"-t", "--fqType"},

--- a/astra-cli/src/main/resources/log4j.properties
+++ b/astra-cli/src/main/resources/log4j.properties
@@ -1,5 +1,0 @@
-log4j.rootLogger=INFO, CONSOLE
-
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%p - %m%n

--- a/astra-cli/src/main/resources/logback.xml
+++ b/astra-cli/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%level - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+</configuration>

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/MethodMatcher.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/MethodMatcher.java
@@ -12,7 +12,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.alfasoftware.astra.core.utils.AstraUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -28,7 +29,7 @@ import org.eclipse.jdt.core.dom.MethodInvocation;
  */
 public class MethodMatcher {
 
-  private static final Logger log = Logger.getLogger(MethodMatcher.class);
+  private static final Logger log = LoggerFactory.getLogger(MethodMatcher.class);
 
   private Optional<DescribedPredicate<String>> fullyQualifiedDeclaringTypePredicate = Optional.empty();
   private Optional<String> fullyQualifiedDeclaringTypeExactName = Optional.empty();

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/annotations/AnnotationChangeRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/annotations/AnnotationChangeRefactor.java
@@ -10,7 +10,8 @@ import java.util.stream.Collectors;
 import org.alfasoftware.astra.core.matchers.AnnotationMatcher;
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Annotation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -38,7 +39,7 @@ public class AnnotationChangeRefactor implements ASTOperation {
 
   private static final String VALUE = "value";
 
-  private static final Logger log = Logger.getLogger(AnnotationChangeRefactor.class);
+  private static final Logger log = LoggerFactory.getLogger(AnnotationChangeRefactor.class);
 
   private final AnnotationMatcher fromType;
   private final String toType;

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/annotations/RemoveAnnotationRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/annotations/RemoveAnnotationRefactor.java
@@ -5,7 +5,8 @@ import java.io.IOException;
 import org.alfasoftware.astra.core.matchers.AnnotationMatcher;
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Annotation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -18,7 +19,7 @@ import org.eclipse.text.edits.MalformedTreeException;
  */
 public class RemoveAnnotationRefactor implements ASTOperation {
 
-  private static final Logger log = Logger.getLogger(AnnotationChangeRefactor.class);
+  private static final Logger log = LoggerFactory.getLogger(AnnotationChangeRefactor.class);
 
   private final AnnotationMatcher annotationToRemove;
 

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/javadoc/JavadocTagRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/javadoc/JavadocTagRefactor.java
@@ -5,7 +5,8 @@ import java.util.Objects;
 
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.TagElement;
@@ -20,7 +21,7 @@ import org.eclipse.text.edits.MalformedTreeException;
  */
 public class JavadocTagRefactor implements ASTOperation {
 
-  private static final Logger log = Logger.getLogger(JavadocTagRefactor.class);
+  private static final Logger log = LoggerFactory.getLogger(JavadocTagRefactor.class);
 
   private final String fromTag;
   private final String toTag;

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/ConstructorToBuilderRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/ConstructorToBuilderRefactor.java
@@ -9,7 +9,8 @@ import java.util.stream.Collectors;
 import org.alfasoftware.astra.core.matchers.MethodMatcher;
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -55,7 +56,7 @@ import org.eclipse.text.edits.MalformedTreeException;
 @SuppressWarnings("unchecked")
 public class ConstructorToBuilderRefactor implements ASTOperation {
 
-  private static final Logger log = Logger.getLogger(ConstructorToBuilderRefactor.class);
+  private static final Logger log = LoggerFactory.getLogger(ConstructorToBuilderRefactor.class);
 
   private final MethodMatcher methodMatcher;
   private final List<BuilderSection> builderParts;

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/MethodDeclaringTypeRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/MethodDeclaringTypeRefactor.java
@@ -13,7 +13,8 @@ import org.alfasoftware.astra.core.matchers.MethodMatcher;
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraUtils;
 import org.alfasoftware.astra.core.utils.ClassVisitor;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ITypeBinding;
@@ -44,7 +45,7 @@ import org.eclipse.text.edits.MalformedTreeException;
  */
 public class MethodDeclaringTypeRefactor implements ASTOperation {
 
-  private static final Logger log = Logger.getLogger(MethodDeclaringTypeRefactor.class);
+  private static final Logger log = LoggerFactory.getLogger(MethodDeclaringTypeRefactor.class);
 
   private final String toType;
   @SuppressWarnings("unused")

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/MethodInvocationRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/MethodInvocationRefactor.java
@@ -9,7 +9,8 @@ import java.util.Optional;
 import org.alfasoftware.astra.core.matchers.MethodMatcher;
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.MethodInvocation;
@@ -40,7 +41,7 @@ import org.eclipse.text.edits.MalformedTreeException;
  */
 public class MethodInvocationRefactor implements ASTOperation {
 
-  private static final Logger log = Logger.getLogger(MethodInvocationRefactor.class);
+  private static final Logger log = LoggerFactory.getLogger(MethodInvocationRefactor.class);
 
   private final MethodMatcher beforeMatcher;
   private final Optional<String> afterType;

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/MethodWithSingleArgumentToSupplier.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/MethodWithSingleArgumentToSupplier.java
@@ -7,7 +7,8 @@ import java.io.IOException;
 import org.alfasoftware.astra.core.matchers.MethodMatcher;
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.LambdaExpression;
@@ -27,7 +28,7 @@ import org.eclipse.text.edits.MalformedTreeException;
  */
 public class MethodWithSingleArgumentToSupplier implements ASTOperation {
 
-  private static final Logger log = Logger.getLogger(MethodInvocationRefactor.class);
+  private static final Logger log = LoggerFactory.getLogger(MethodWithSingleArgumentToSupplier.class);
 
   private final MethodMatcher before;
 

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/RemoveMethodDeclarationRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/RemoveMethodDeclarationRefactor.java
@@ -6,7 +6,8 @@ import java.util.stream.Collectors;
 import org.alfasoftware.astra.core.matchers.MethodMatcher;
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
@@ -49,7 +50,7 @@ import org.eclipse.text.edits.MalformedTreeException;
  */
 public class RemoveMethodDeclarationRefactor implements ASTOperation {
   
-  private static final Logger log = Logger.getLogger(RemoveMethodDeclarationRefactor.class);
+  private static final Logger log = LoggerFactory.getLogger(RemoveMethodDeclarationRefactor.class);
 
   private final MethodMatcher matcher;
 

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/UnwrapAndRemoveMethodInvocationRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/methods/UnwrapAndRemoveMethodInvocationRefactor.java
@@ -10,7 +10,8 @@ import org.alfasoftware.astra.core.matchers.MethodMatcher;
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraUtils;
 import org.alfasoftware.astra.core.utils.AstraUtils.MethodInvocationType;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -49,7 +50,7 @@ import org.eclipse.text.edits.MalformedTreeException;
  */
 public class UnwrapAndRemoveMethodInvocationRefactor implements ASTOperation {
 
-  private static final Logger log = Logger.getLogger(UnwrapAndRemoveMethodInvocationRefactor.class);
+  private static final Logger log = LoggerFactory.getLogger(UnwrapAndRemoveMethodInvocationRefactor.class);
 
   private final MethodMatcher beforeMatcher;
   private final Optional<String> afterType;

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/InlineInterfaceRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/InlineInterfaceRefactor.java
@@ -18,7 +18,8 @@ import java.util.stream.Stream;
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraUtils;
 import org.alfasoftware.astra.core.utils.ClassVisitor;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ITypeBinding;
@@ -45,7 +46,7 @@ import org.eclipse.text.edits.MalformedTreeException;
  */
 public class InlineInterfaceRefactor implements ASTOperation {
 
-  private static final Logger log = Logger.getLogger(InlineInterfaceRefactor.class);
+  private static final Logger log = LoggerFactory.getLogger(InlineInterfaceRefactor.class);
 
   private final String interfaceName;
   private ClassVisitor interfaceVisitor;
@@ -62,7 +63,7 @@ public class InlineInterfaceRefactor implements ASTOperation {
       compilationUnit.accept(interfaceVisitor);
 
     } catch (IOException e) {
-      log.error(e);
+      log.error("Failed to read interface file", e);
     }
   }
 

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/TypeReferenceRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/TypeReferenceRefactor.java
@@ -8,7 +8,8 @@ import java.util.Set;
 
 import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -55,7 +56,7 @@ import org.eclipse.text.edits.MalformedTreeException;
  */
 public class TypeReferenceRefactor implements ASTOperation {
 
-  private static final Logger log = Logger.getLogger(TypeReferenceRefactor.class);
+  private static final Logger log = LoggerFactory.getLogger(TypeReferenceRefactor.class);
 
   private final String fromType;
   private final String toType;

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/UpdateTypeRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/UpdateTypeRefactor.java
@@ -12,7 +12,8 @@ import org.alfasoftware.astra.core.utils.ASTOperation;
 import org.alfasoftware.astra.core.utils.AstraUtils;
 import org.alfasoftware.astra.core.utils.ClassVisitor;
 import org.alfasoftware.astra.core.utils.CompilationUnitProperty;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.IBinding;
@@ -39,7 +40,7 @@ import org.eclipse.text.edits.MalformedTreeException;
  */
 public class UpdateTypeRefactor implements ASTOperation {
 
-  private static final Logger log = Logger.getLogger(UpdateTypeRefactor.class);
+  private static final Logger log = LoggerFactory.getLogger(UpdateTypeRefactor.class);
 
   private final String fromType;
   private final String toType;

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/utils/AstraCore.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/utils/AstraCore.java
@@ -22,7 +22,8 @@ import java.util.stream.Stream;
 
 import org.alfasoftware.astra.core.refactoring.UseCase;
 import org.alfasoftware.astra.core.refactoring.operations.imports.UnusedImportRefactor;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jface.text.BadLocationException;
@@ -40,7 +41,7 @@ import org.eclipse.text.edits.MalformedTreeException;
  */
 public class AstraCore {
 
-  protected static final Logger log = Logger.getLogger(AstraCore.class);
+  protected static final Logger log = LoggerFactory.getLogger(AstraCore.class);
 
 
   /**

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/utils/AstraCore.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/utils/AstraCore.java
@@ -129,7 +129,7 @@ public class AstraCore {
       progressMessage.append(" elapsed, estimated [" + remainingDuration.toMinutes() + "] minutes remaining");
     }
 
-    log.info(progressMessage);
+    log.info(progressMessage.toString());
   }
 
 

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/utils/AstraUtils.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/utils/AstraUtils.java
@@ -12,7 +12,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.alfasoftware.astra.core.matchers.AnnotationMatcher;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.dom.AST;
@@ -55,7 +56,7 @@ import org.eclipse.jface.text.BadLocationException;
  */
 public class AstraUtils {
 
-  private static final Logger log = Logger.getLogger(AstraUtils.class);
+  private static final Logger log = LoggerFactory.getLogger(AstraUtils.class);
   public static final String CLASSPATHS_MISSING_WARNING = "This may be a sign that classpaths for the operation need to be supplied. ";
 
   public static CompilationUnit readAsCompilationUnit(Path file, String fileSource, String[] sources, String[] classPath) {

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/utils/ClassVisitor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/utils/ClassVisitor.java
@@ -7,7 +7,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
@@ -44,7 +45,7 @@ import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
  */
 public class ClassVisitor extends ASTVisitor {
 
-  private static final Logger log = Logger.getLogger(ClassVisitor.class);
+  private static final Logger log = LoggerFactory.getLogger(ClassVisitor.class);
 
   private final List<AbstractTypeDeclaration> abstractTypeDeclarations = new ArrayList<>();
   private final List<TypeParameter> typeParameters = new ArrayList<>();

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/utils/MethodDeclarationVisitor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/utils/MethodDeclarationVisitor.java
@@ -1,6 +1,7 @@
 package org.alfasoftware.astra.core.utils;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 
@@ -12,7 +13,7 @@ import java.util.List;
  */
 public class MethodDeclarationVisitor extends ASTVisitor {
 
-  private static final Logger log = Logger.getLogger(MethodDeclarationVisitor.class);
+  private static final Logger log = LoggerFactory.getLogger(MethodDeclarationVisitor.class);
 
   private final List<MethodDeclaration> methodDeclarations = new ArrayList<>();
 

--- a/astra-core/src/main/resources/log4j.properties
+++ b/astra-core/src/main/resources/log4j.properties
@@ -1,5 +1,0 @@
-log4j.rootLogger=INFO, CONSOLE
-
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%p - %m%n

--- a/astra-core/src/main/resources/logback.xml
+++ b/astra-core/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%level - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
     <maven.baseVersion>3.8.2</maven.baseVersion>
 
     <!-- dependency versions -->
-    <log4j.version>1.2.17</log4j.version>
+    <slf4j.version>2.0.17</slf4j.version>
+    <logback.version>1.5.18</logback.version>
     <junit.version>4.13.2</junit.version>
     
     <!-- sonar properties -->
@@ -69,9 +70,16 @@
       </dependency>
       
       <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>${log4j.version}</version>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+        <scope>runtime</scope>
       </dependency>
 
       <dependency>
@@ -103,8 +111,14 @@
   
   <dependencies>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
     </dependency>
         
     <dependency>


### PR DESCRIPTION
- Replace log4j:log4j:1.2.17 with slf4j-api:2.0.17 and logback-classic:1.5.18
- Update all 19 Java source files: replace org.apache.log4j.Logger import with org.slf4j.{Logger,LoggerFactory} and Logger.getLogger() with LoggerFactory.getLogger()
- Fix log.error(e) in InlineInterfaceRefactor (SLF4J has no error(Throwable) overload) to log.error(message, e)
- Fix mismatched logger class in MethodWithSingleArgumentToSupplier (was incorrectly using MethodInvocationRefactor.class)
- Replace log4j.properties in astra-core and astra-cli with logback.xml using equivalent config (INFO level, console appender, "%level - %msg%n")