### PR TITLE
Add TypeMatcher Java 16-21 language feature support

### DIFF
--- a/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/TypeMatcher.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/TypeMatcher.java
@@ -8,9 +8,12 @@ import java.util.function.Predicate;
 
 import org.alfasoftware.astra.core.utils.AstraUtils;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.EnumDeclaration;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.RecordDeclaration;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 
@@ -46,13 +49,17 @@ public class TypeMatcher implements Matcher {
   public static class TypeBuilder implements Builder {
     private Boolean isInterface;
     private Boolean isClass;
+    private Boolean isRecord;
     private String typeName;
     private Set<String> interfaces;
     private String superClass;
+    private Set<String> permittedTypes;
     private Visibility visibility;
     private Boolean isStatic;
     private Boolean isAbstract;
     private Boolean isFinal;
+    private Boolean isSealed;
+    private Boolean isNonSealed;
     private String typeNameRegex;
     private Predicate<String> typeNamePredicate;
 
@@ -91,6 +98,16 @@ public class TypeMatcher implements Matcher {
      */
     public TypeBuilder asClass() {
       isClass = true;
+      return this;
+    }
+
+    /**
+     * Specifies the type must be a record.
+     *
+     * @return the builder
+     */
+    public TypeBuilder asRecord() {
+      isRecord = true;
       return this;
     }
 
@@ -150,6 +167,19 @@ public class TypeMatcher implements Matcher {
      */
     public TypeBuilder implementingInterfaces(Set<String> interfaceNames) {
       interfaces = interfaceNames;
+      return this;
+    }
+
+    /**
+     * Specifies fully qualified names that the type must declare in its {@code permits} clause.
+     * This can be used to match a sealed type by the subtypes it permits.
+     * All supplied names must be present in the permits clause for the type to match.
+     *
+     * @param permittedTypeNames fully qualified names the type must permit
+     * @return the builder
+     */
+    public TypeBuilder permitting(Set<String> permittedTypeNames) {
+      permittedTypes = permittedTypeNames;
       return this;
     }
 
@@ -228,6 +258,26 @@ public class TypeMatcher implements Matcher {
       isFinal = true;
       return this;
     }
+
+    /**
+     * Specifies the type must be sealed.
+     *
+     * @return the builder
+     */
+    public TypeBuilder isSealed() {
+      isSealed = true;
+      return this;
+    }
+
+    /**
+     * Specifies the type must be non-sealed.
+     *
+     * @return the builder
+     */
+    public TypeBuilder isNonSealed() {
+      isNonSealed = true;
+      return this;
+    }
   }
 
   /**
@@ -248,17 +298,27 @@ public class TypeMatcher implements Matcher {
   @Override
   public boolean matches(ASTNode node) {
 
-    if (!(node instanceof TypeDeclaration)) {
+    if (!(node instanceof AbstractTypeDeclaration)) {
       return false;
     }
-    TypeDeclaration typeDeclaration = (TypeDeclaration) node;
+    AbstractTypeDeclaration typeDeclaration = (AbstractTypeDeclaration) node;
 
-    if (! checkIsInterface(typeDeclaration)) {
+    // Class/interface/record gates. A record only matches asRecord(), and asClass()/asInterface()
+    // only match TypeDeclarations - mirroring how enums are excluded.
+    if (! checkIsRecord(node)) {
       return false;
     }
-    if (! checkIsClass(typeDeclaration)) {
+    if (node instanceof TypeDeclaration) {
+      if (! checkIsInterface((TypeDeclaration) node)) {
+        return false;
+      }
+      if (! checkIsClass((TypeDeclaration) node)) {
+        return false;
+      }
+    } else if (Boolean.TRUE.equals(typeBuilder.isClass) || Boolean.TRUE.equals(typeBuilder.isInterface)) {
       return false;
     }
+
     if (! checkTypeName(typeDeclaration)) {
       return false;
     }
@@ -286,7 +346,60 @@ public class TypeMatcher implements Matcher {
     if (! checkIsFinal(typeDeclaration)) {
       return false;
     }
-    return checkSuperclass(typeDeclaration);
+    if (! checkIsSealed(typeDeclaration)) {
+      return false;
+    }
+    if (! checkIsNonSealed(typeDeclaration)) {
+      return false;
+    }
+    if (! checkPermittedTypes(node)) {
+      return false;
+    }
+
+    // Superclasses only apply to a TypeDeclaration. If a superclass was required, anything else fails.
+    if (node instanceof TypeDeclaration) {
+      return checkSuperclass((TypeDeclaration) node);
+    }
+    return typeBuilder.superClass == null;
+  }
+
+  private boolean checkIsRecord(ASTNode node) {
+    return typeBuilder.isRecord == null || (typeBuilder.isRecord == (node instanceof RecordDeclaration));
+  }
+
+  /**
+   * Checks the fully qualified names declared in the type's {@code permits} clause against those expected.
+   *
+   * @param node the node being checked
+   * @return true if all expected permitted types are present, false otherwise
+   */
+  private boolean checkPermittedTypes(ASTNode node) {
+    if (typeBuilder.permittedTypes == null) {
+      return true;
+    }
+    if (! (node instanceof TypeDeclaration)) {
+      return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    List<Type> declaredPermittedTypes = ((TypeDeclaration) node).permittedTypes();
+    Set<String> permittedNames = new HashSet<>();
+    for (Type permittedType : declaredPermittedTypes) {
+      ITypeBinding binding = permittedType.resolveBinding();
+      if (binding != null) {
+        permittedNames.add(binding.getQualifiedName());
+        permittedNames.add(binding.getBinaryName());
+      }
+    }
+    return permittedNames.containsAll(typeBuilder.permittedTypes);
+  }
+
+  private boolean checkIsSealed(AbstractTypeDeclaration typeDeclaration) {
+    return typeBuilder.isSealed == null || checkForModifier(typeDeclaration, Modifier::isSealed);
+  }
+
+  private boolean checkIsNonSealed(AbstractTypeDeclaration typeDeclaration) {
+    return typeBuilder.isNonSealed == null || checkForModifier(typeDeclaration, Modifier::isNonSealed);
   }
 
   private boolean checkSuperclass(TypeDeclaration typeDeclaration) {
@@ -338,7 +451,7 @@ public class TypeMatcher implements Matcher {
    * @param typeDeclaration the type being checked
    * @return true if it matches, false otherwise
    */
-  private boolean checkTypeName(final TypeDeclaration typeDeclaration) {
+  private boolean checkTypeName(final AbstractTypeDeclaration typeDeclaration) {
     return typeBuilder.typeName == null ||
         typeBuilder.typeName.equals(AstraUtils.getFullyQualifiedName(typeDeclaration));
   }
@@ -349,7 +462,7 @@ public class TypeMatcher implements Matcher {
    * @param typeDeclaration the type being checked
    * @return true if it matches, false otherwise
    */
-  private boolean checkClassNameRegex(final TypeDeclaration typeDeclaration) {
+  private boolean checkClassNameRegex(final AbstractTypeDeclaration typeDeclaration) {
     return typeBuilder.typeNameRegex == null ||
         AstraUtils.getFullyQualifiedName(typeDeclaration).matches(typeBuilder.typeNameRegex);
   }
@@ -360,7 +473,7 @@ public class TypeMatcher implements Matcher {
    * @param typeDeclaration the type being checked
    * @return true if it matches, false otherwise
    */
-  private boolean checkTypeNamePredicate(final TypeDeclaration typeDeclaration) {
+  private boolean checkTypeNamePredicate(final AbstractTypeDeclaration typeDeclaration) {
     return typeBuilder.typeNamePredicate == null ||
         typeBuilder.typeNamePredicate.test(AstraUtils.getFullyQualifiedName(typeDeclaration));
   }
@@ -371,7 +484,7 @@ public class TypeMatcher implements Matcher {
    * @param typeDeclaration the type being checked
    * @return true if all interfaces expected are present, false otherwise
    */
-  private boolean checkInterfaces(final TypeDeclaration typeDeclaration) {
+  private boolean checkInterfaces(final AbstractTypeDeclaration typeDeclaration) {
     if (typeBuilder.interfaces == null) {
       return true;
     }
@@ -394,9 +507,8 @@ public class TypeMatcher implements Matcher {
   }
 
 
-  private Set<ITypeBinding> getAllInterfaces(TypeDeclaration typeDeclaration) {
-    @SuppressWarnings("unchecked")
-    List<Type> superInterfaceTypes = typeDeclaration.superInterfaceTypes();
+  private Set<ITypeBinding> getAllInterfaces(AbstractTypeDeclaration typeDeclaration) {
+    List<Type> superInterfaceTypes = getSuperInterfaceTypes(typeDeclaration);
     Set<ITypeBinding> interfaces = new HashSet<>();
     for (Type interfaceName : superInterfaceTypes) {
       interfaces.add(interfaceName.resolveBinding());
@@ -404,6 +516,25 @@ public class TypeMatcher implements Matcher {
     }
     getSuperClassInterfaces(typeDeclaration.resolveBinding(), interfaces);
     return interfaces;
+  }
+
+
+  /**
+   * Returns the declared super-interface types for a type. Records, enums and ordinary types each
+   * expose these separately, so they are unified here.
+   */
+  @SuppressWarnings("unchecked")
+  private List<Type> getSuperInterfaceTypes(AbstractTypeDeclaration typeDeclaration) {
+    if (typeDeclaration instanceof TypeDeclaration) {
+      return ((TypeDeclaration) typeDeclaration).superInterfaceTypes();
+    }
+    if (typeDeclaration instanceof RecordDeclaration) {
+      return ((RecordDeclaration) typeDeclaration).superInterfaceTypes();
+    }
+    if (typeDeclaration instanceof EnumDeclaration) {
+      return ((EnumDeclaration) typeDeclaration).superInterfaceTypes();
+    }
+    return new ArrayList<>();
   }
 
 
@@ -434,7 +565,7 @@ public class TypeMatcher implements Matcher {
    * @param typeDeclaration the type being checked
    * @return true if all annotations expected are present, false otherwise
    */
-  private boolean checkAnnotations(final TypeDeclaration typeDeclaration) {
+  private boolean checkAnnotations(final AbstractTypeDeclaration typeDeclaration) {
     if (typeBuilder.annotationBuilders == null) {
       return true;
     }
@@ -463,7 +594,7 @@ public class TypeMatcher implements Matcher {
    * @param typeDeclaration type to check
    * @return true if the visibilty is correct, false otherwise
    */
-  private boolean checkVisibility(final TypeDeclaration typeDeclaration) {
+  private boolean checkVisibility(final AbstractTypeDeclaration typeDeclaration) {
     if (typeBuilder.visibility == null) {
       return true;
     }
@@ -481,7 +612,7 @@ public class TypeMatcher implements Matcher {
    * @param typeDeclaration the type to check
    * @return true if it is static, false otherwise
    */
-  private boolean checkIsStatic(final TypeDeclaration typeDeclaration) {
+  private boolean checkIsStatic(final AbstractTypeDeclaration typeDeclaration) {
     return typeBuilder.isStatic == null || checkForModifier(typeDeclaration, Modifier::isStatic);
   }
 
@@ -491,7 +622,7 @@ public class TypeMatcher implements Matcher {
    * @param typeDeclaration the type to check
    * @return true if it is abstract, false otherwise
    */
-  private boolean checkIsAbstract(final TypeDeclaration typeDeclaration) {
+  private boolean checkIsAbstract(final AbstractTypeDeclaration typeDeclaration) {
     return typeBuilder.isAbstract == null || checkForModifier(typeDeclaration, Modifier::isAbstract);
   }
 
@@ -501,7 +632,7 @@ public class TypeMatcher implements Matcher {
    * @param typeDeclaration the type to check
    * @return true if it is final, false otherwise
    */
-  private boolean checkIsFinal(final TypeDeclaration typeDeclaration) {
+  private boolean checkIsFinal(final AbstractTypeDeclaration typeDeclaration) {
     return typeBuilder.isFinal == null || checkForModifier(typeDeclaration, Modifier::isFinal);
   }
 
@@ -512,7 +643,7 @@ public class TypeMatcher implements Matcher {
    * @param check           a predicate to check on the type
    * @return the result of the predicate as applied to the type definition
    */
-  private boolean checkForModifier(final TypeDeclaration typeDeclaration, Predicate<Modifier> check) {
+  private boolean checkForModifier(final AbstractTypeDeclaration typeDeclaration, Predicate<Modifier> check) {
     for (Object modifier : typeDeclaration.modifiers()) {
       if (modifier instanceof Modifier) {
         Modifier theModifier = (Modifier) modifier;

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/TypeReferenceRefactor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/refactoring/operations/types/TypeReferenceRefactor.java
@@ -12,17 +12,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IDocElement;
+import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.Javadoc;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodRef;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.TagElement;
-import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.text.edits.MalformedTreeException;
@@ -116,14 +118,15 @@ public class TypeReferenceRefactor implements ASTOperation {
 
     if (node instanceof SimpleName) {
       updateSimpleName(compilationUnit, (SimpleName) node, rewriter);
+      updateConstructorName(compilationUnit, (SimpleName) node, rewriter);
     }
 
     if (node instanceof QualifiedName) {
       updateQualifiedName(compilationUnit, (QualifiedName) node, rewriter);
     }
 
-    if (node instanceof TypeDeclaration) {
-      updateJavadocTypes(compilationUnit, (TypeDeclaration) node, rewriter);
+    if (node instanceof AbstractTypeDeclaration) {
+      updateJavadocTypes(compilationUnit, (AbstractTypeDeclaration) node, rewriter);
     }
   }
 
@@ -134,6 +137,34 @@ public class TypeReferenceRefactor implements ASTOperation {
     	binding instanceof ITypeBinding &&
     	((ITypeBinding) binding).getQualifiedName().equals(getFromType())) {
       log.info("Refactoring simple type [" + name.toString() + "] to [" + AstraUtils.getSimpleName(toType) + "] in [" +
+          AstraUtils.getNameForCompilationUnit(compilationUnit) + "]");
+      rewriter.set(name, SimpleName.IDENTIFIER_PROPERTY, AstraUtils.getSimpleName(toType), null);
+    }
+  }
+
+
+  /**
+   * Renames the name of a constructor declaration where the declaring type is being renamed.
+   *
+   * <p>A constructor's name resolves to an {@link IMethodBinding} rather than an {@link ITypeBinding},
+   * so {@link #updateSimpleName} skips it. This handles both ordinary constructors and a record's
+   * compact (or canonical) constructor, e.g. the {@code Foo} in {@code record Foo(...) { Foo {...} }}.
+   */
+  private void updateConstructorName(CompilationUnit compilationUnit, SimpleName name, ASTRewrite rewriter) {
+    if (! (name.getParent() instanceof MethodDeclaration)) {
+      return;
+    }
+    MethodDeclaration methodDeclaration = (MethodDeclaration) name.getParent();
+    if (methodDeclaration.getName() != name ||
+        ! (methodDeclaration.isConstructor() || methodDeclaration.isCompactConstructor())) {
+      return;
+    }
+
+    IMethodBinding methodBinding = methodDeclaration.resolveBinding();
+    if (methodBinding != null &&
+        methodBinding.getDeclaringClass() != null &&
+        methodBinding.getDeclaringClass().getQualifiedName().equals(getFromType())) {
+      log.info("Refactoring constructor name [" + name.toString() + "] to [" + AstraUtils.getSimpleName(toType) + "] in [" +
           AstraUtils.getNameForCompilationUnit(compilationUnit) + "]");
       rewriter.set(name, SimpleName.IDENTIFIER_PROPERTY, AstraUtils.getSimpleName(toType), null);
     }
@@ -151,7 +182,7 @@ public class TypeReferenceRefactor implements ASTOperation {
   }
 
 
-  private void updateJavadocTypes(CompilationUnit compilationUnit, TypeDeclaration typeDeclaration, ASTRewrite rewriter) {
+  private void updateJavadocTypes(CompilationUnit compilationUnit, AbstractTypeDeclaration typeDeclaration, ASTRewrite rewriter) {
     if (typeDeclaration.resolveBinding() != null && ! typeDeclaration.resolveBinding().isNested()) {
       // Special handling for Javadoc references to types
       JavadocVisitor visitor = new JavadocVisitor();

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/utils/ClassVisitor.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/utils/ClassVisitor.java
@@ -28,8 +28,10 @@ import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.NormalAnnotation;
 import org.eclipse.jdt.core.dom.ParameterizedType;
+import org.eclipse.jdt.core.dom.PatternInstanceofExpression;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.QualifiedType;
+import org.eclipse.jdt.core.dom.RecordDeclaration;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SimpleType;
 import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
@@ -61,6 +63,7 @@ public class ClassVisitor extends ASTVisitor {
   private final List<MarkerAnnotation> markerAnnotations = new ArrayList<>();
   private final List<ClassInstanceCreation> classInstanceCreations = new ArrayList<>();
   private final List<TagElement> tagElements = new ArrayList<>();
+  private final List<PatternInstanceofExpression> patternInstanceofExpressions = new ArrayList<>();
 
   private final List<FieldAccess> fieldAccesses = new ArrayList<>();
   private final List<CastExpression> castExpressions = new ArrayList<>();
@@ -105,6 +108,20 @@ public class ClassVisitor extends ASTVisitor {
   @Override
   public boolean visit(EnumDeclaration node) {
     abstractTypeDeclarations.add(node);
+    return super.visit(node);
+  }
+
+  @Override
+  public boolean visit(RecordDeclaration node) {
+    log.debug("Record declar: " + node);
+    abstractTypeDeclarations.add(node);
+    return super.visit(node);
+  }
+
+  @Override
+  public boolean visit(PatternInstanceofExpression node) {
+    log.debug("Pattern instanceof: " + node);
+    patternInstanceofExpressions.add(node);
     return super.visit(node);
   }
 
@@ -274,6 +291,17 @@ public class ClassVisitor extends ASTVisitor {
         .collect(Collectors.toList());
   }
 
+  public List<RecordDeclaration> getRecordDeclarations() {
+    return abstractTypeDeclarations.stream()
+        .filter(RecordDeclaration.class::isInstance)
+        .map(RecordDeclaration.class::cast)
+        .collect(Collectors.toList());
+  }
+
+  public List<PatternInstanceofExpression> getPatternInstanceofExpressions() {
+    return patternInstanceofExpressions;
+  }
+
   public List<ParameterizedType> getParameterizedTypes() {
     return parameterizedTypes;
   }
@@ -391,7 +419,8 @@ public class ClassVisitor extends ASTVisitor {
       getTagElements(),
       getImports(),
       getFieldAccesses(),
-      getCastExpressions())
+      getCastExpressions(),
+      getPatternInstanceofExpressions())
     .flatMap(Collection::stream)
     .collect(Collectors.toSet());
   }

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/ExampleClassUsingRecord.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/ExampleClassUsingRecord.java
@@ -1,0 +1,14 @@
+package org.alfasoftware.astra.core.matchers;
+
+import org.alfasoftware.astra.exampleTypes.RecordA;
+
+public class ExampleClassUsingRecord {
+
+  @SuppressWarnings("unused")
+  public void use() {
+    RecordA r = new RecordA(1, "a");
+    int v = r.value();
+    String n = r.name();
+    String d = r.describe();
+  }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestMethodMatcher.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestMethodMatcher.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 
 import org.alfasoftware.astra.core.utils.AstraUtils;
 import org.alfasoftware.astra.core.utils.ClassVisitor;
+import org.alfasoftware.astra.exampleTypes.RecordA;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
@@ -427,6 +428,29 @@ public class TestMethodMatcher {
     checkNoMethodMatchFoundInClass(methodInvocationMatcher, ExampleClassUsingMethodWithClassParameter.class);
     checkMethodMatchFoundInClass(classInstanceCreationMatcher, ExampleClassUsingMultipleMethods.class);
     checkNoMethodMatchFoundInClass(classInstanceCreationMatcherNoMatch, ExampleClassUsingMultipleMethods.class);
+  }
+
+
+  /**
+   * Tests that a record's accessor method and its canonical constructor can be matched
+   * by their declaring type and name.
+   */
+  @Test
+  public void testMatchRecordAccessorAndConstructor() {
+
+    MethodMatcher accessorMatcher = MethodMatcher.builder()
+        .withFullyQualifiedDeclaringType(RecordA.class.getName())
+        .withMethodName("value")
+        .build();
+
+    MethodMatcher constructorMatcher = MethodMatcher.builder()
+        .withFullyQualifiedDeclaringType(RecordA.class.getName())
+        .withMethodName(RecordA.class.getSimpleName())
+        .build();
+
+    // Accessor invocation and constructor invocation are visible from the usage site
+    checkMethodMatchFoundInClass(accessorMatcher, ExampleClassUsingRecord.class);
+    checkMethodMatchFoundInClass(constructorMatcher, ExampleClassUsingRecord.class);
   }
 
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestTypeMatcher.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestTypeMatcher.java
@@ -722,6 +722,86 @@ public class TestTypeMatcher {
   }
 
 
+  @Test
+  public void testTypeMatcherForRecord() {
+    Matcher matcher = TypeMatcher.builder().asRecord().build();
+    ClassVisitor visitor = parse("package x; public record Rec(int value) {}");
+    assertTrue(matcher.matches(visitor.getAbstractTypeDeclarations().get(0)));
+  }
+
+
+  @Test
+  public void testTypeMatcherForRecordWithName() {
+    Matcher matcher = TypeMatcher.builder().asRecord().withName("x.Rec").build();
+    ClassVisitor visitor = parse("package x; public record Rec(int value) {}");
+    assertTrue(matcher.matches(visitor.getAbstractTypeDeclarations().get(0)));
+  }
+
+
+  @Test
+  public void testTypeMatcherForRecordDoesNotMatchClass() {
+    Matcher matcher = TypeMatcher.builder().asRecord().build();
+    ClassVisitor visitor = parse(SIMPLE_CLASS);
+    assertFalse(matcher.matches(visitor.getTypeDeclarations().get(0)));
+  }
+
+
+  @Test
+  public void testTypeMatcherForClassDoesNotMatchRecord() {
+    Matcher matcher = TypeMatcher.builder().asClass().build();
+    ClassVisitor visitor = parse("package x; public record Rec(int value) {}");
+    assertFalse(matcher.matches(visitor.getAbstractTypeDeclarations().get(0)));
+  }
+
+
+  @Test
+  public void testTypeMatcherForSealedClass() {
+    Matcher matcher = TypeMatcher.builder().asClass().isSealed().build();
+    ClassVisitor visitor = parse("package x; sealed class Shape permits Circle {} final class Circle extends Shape {}");
+    assertTrue(matcher.matches(visitor.getTypeDeclarations().get(0)));
+  }
+
+
+  @Test
+  public void testTypeMatcherForSealedClassWhenItIsNot() {
+    Matcher matcher = TypeMatcher.builder().asClass().isSealed().build();
+    ClassVisitor visitor = parse(SIMPLE_CLASS);
+    assertFalse(matcher.matches(visitor.getTypeDeclarations().get(0)));
+  }
+
+
+  @Test
+  public void testTypeMatcherForNonSealedClass() {
+    Matcher matcher = TypeMatcher.builder().asClass().isNonSealed().build();
+    ClassVisitor visitor = parse("package x; sealed class Shape permits Circle {} non-sealed class Circle extends Shape {}");
+    assertTrue(matcher.matches(visitor.getTypeDeclarations().get(1)));
+  }
+
+
+  @Test
+  public void testTypeMatcherForNonSealedClassWhenItIsNot() {
+    Matcher matcher = TypeMatcher.builder().asClass().isNonSealed().build();
+    ClassVisitor visitor = parse("package x; sealed class Shape permits Circle {} non-sealed class Circle extends Shape {}");
+    assertFalse(matcher.matches(visitor.getTypeDeclarations().get(0)));
+  }
+
+
+  @Test
+  public void testTypeMatcherForPermittedTypes() {
+    Matcher matcher = TypeMatcher.builder().asClass().isSealed().permitting(Set.of("x.Circle")).build();
+    ClassVisitor visitor = parse("package x; sealed class Shape permits Circle {} final class Circle extends Shape {}");
+    assertTrue(matcher.matches(visitor.getTypeDeclarations().get(0)));
+  }
+
+
+  @Test
+  public void testTypeMatcherForPermittedTypesWhenNotPermitted() {
+    Matcher matcher = TypeMatcher.builder().asClass().permitting(Set.of("x.Square")).build();
+    ClassVisitor visitor = parse("package x; sealed class Shape permits Circle {} final class Circle extends Shape {}");
+    assertFalse(matcher.matches(visitor.getTypeDeclarations().get(0)));
+  }
+
+
   private ClassVisitor parse(String source) {
     CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(Path.of(""), source, new String[]{TEST_SOURCE}, new String[0]);
     ClassVisitor visitor = new ClassVisitor();

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TestTypeReferenceRefactor.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TestTypeReferenceRefactor.java
@@ -12,6 +12,8 @@ import org.alfasoftware.astra.exampleTypes.B;
 import org.alfasoftware.astra.exampleTypes.B.InnerAnnotationB;
 import org.alfasoftware.astra.exampleTypes.EnumA;
 import org.alfasoftware.astra.exampleTypes.EnumB;
+import org.alfasoftware.astra.exampleTypes.RecordA;
+import org.alfasoftware.astra.exampleTypes.RecordB;
 import org.junit.Test;
 
 public class TestTypeReferenceRefactor extends AbstractRefactorTest {
@@ -103,5 +105,51 @@ public class TestTypeReferenceRefactor extends AbstractRefactorTest {
         .fromType(InnerAnnotationA.class.getName())
         .toType(InnerAnnotationB.class.getName())
         .build())));
+  }
+
+
+  /**
+   * Changing from one record type to another, where the record is referenced
+   * as a field, parameter, return type, constructor invocation, instanceof
+   * pattern and in Javadoc.
+   */
+  @Test
+  public void testChangeRecordType() {
+    assertRefactor(TypeReferenceRecordExample.class,
+        new HashSet<>(Arrays.asList(
+          TypeReferenceRefactor.builder()
+            .fromType(RecordA.class.getName())
+            .toType(RecordB.class.getName())
+            .build())));
+  }
+
+
+  /**
+   * Renaming a record type renames its compact constructor's name as well as
+   * the declaration and any constructor invocations.
+   */
+  @Test
+  public void testChangeRecordCompactConstructorName() {
+    assertRefactor(TypeReferenceCompactConstructorExample.class,
+        new HashSet<>(Arrays.asList(
+          TypeReferenceRefactor.builder()
+            .fromType(TypeReferenceCompactConstructorExample.class.getName() + ".Inner")
+            .toType(TypeReferenceCompactConstructorExample.class.getName() + ".InnerRenamed")
+            .build())));
+  }
+
+
+  /**
+   * Changing the tested type in an instanceof pattern, leaving the binding
+   * variable untouched.
+   */
+  @Test
+  public void testChangeTypeInInstanceofPattern() {
+    assertRefactor(TypeReferenceInstanceofPatternExample.class,
+        new HashSet<>(Arrays.asList(
+          TypeReferenceRefactor.builder()
+            .fromType(A.class.getName())
+            .toType(B.class.getName())
+            .build())));
   }
 }

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceCompactConstructorExample.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceCompactConstructorExample.java
@@ -1,0 +1,17 @@
+package org.alfasoftware.astra.core.refactoring.types;
+
+@SuppressWarnings("unused")
+public class TypeReferenceCompactConstructorExample {
+
+  public record Inner(int value) {
+    public Inner {
+      if (value < 0) {
+        throw new IllegalArgumentException("value must not be negative");
+      }
+    }
+  }
+
+  Inner make() {
+    return new Inner(1);
+  }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceCompactConstructorExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceCompactConstructorExampleAfter.java
@@ -1,0 +1,17 @@
+package org.alfasoftware.astra.core.refactoring.types;
+
+@SuppressWarnings("unused")
+public class TypeReferenceCompactConstructorExampleAfter {
+
+  public record InnerRenamed(int value) {
+    public InnerRenamed {
+      if (value < 0) {
+        throw new IllegalArgumentException("value must not be negative");
+      }
+    }
+  }
+
+  InnerRenamed make() {
+    return new InnerRenamed(1);
+  }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceInstanceofPatternExample.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceInstanceofPatternExample.java
@@ -1,0 +1,13 @@
+package org.alfasoftware.astra.core.refactoring.types;
+
+import org.alfasoftware.astra.exampleTypes.A;
+
+public class TypeReferenceInstanceofPatternExample {
+
+  @SuppressWarnings("unused")
+  public void doFoo(Object o) {
+    if (o instanceof A a) {
+      a.one();
+    }
+  }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceInstanceofPatternExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceInstanceofPatternExampleAfter.java
@@ -1,0 +1,13 @@
+package org.alfasoftware.astra.core.refactoring.types;
+
+import org.alfasoftware.astra.exampleTypes.B;
+
+public class TypeReferenceInstanceofPatternExampleAfter {
+
+  @SuppressWarnings("unused")
+  public void doFoo(Object o) {
+    if (o instanceof B a) {
+      a.one();
+    }
+  }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceRecordExample.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceRecordExample.java
@@ -1,0 +1,21 @@
+package org.alfasoftware.astra.core.refactoring.types;
+
+import org.alfasoftware.astra.exampleTypes.RecordA;
+
+/**
+ * {@link RecordA}
+ * {@link org.alfasoftware.astra.exampleTypes.RecordA}
+ */
+public class TypeReferenceRecordExample {
+
+  RecordA field = new RecordA(1, "a");
+
+  @SuppressWarnings("unused")
+  public RecordA doFoo(RecordA param) {
+    Object o = param;
+    if (o instanceof RecordA r) {
+      return r;
+    }
+    return new RecordA(2, "b");
+  }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceRecordExampleAfter.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/refactoring/types/TypeReferenceRecordExampleAfter.java
@@ -1,0 +1,21 @@
+package org.alfasoftware.astra.core.refactoring.types;
+
+import org.alfasoftware.astra.exampleTypes.RecordB;
+
+/**
+ * {@link RecordB}
+ * {@link org.alfasoftware.astra.exampleTypes.RecordB}
+ */
+public class TypeReferenceRecordExampleAfter {
+
+  RecordB field = new RecordB(1, "a");
+
+  @SuppressWarnings("unused")
+  public RecordB doFoo(RecordB param) {
+    Object o = param;
+    if (o instanceof RecordB r) {
+      return r;
+    }
+    return new RecordB(2, "b");
+  }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/exampleTypes/RecordA.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/exampleTypes/RecordA.java
@@ -1,0 +1,14 @@
+package org.alfasoftware.astra.exampleTypes;
+
+public record RecordA(int value, String name) {
+
+  public RecordA {
+    if (value < 0) {
+      throw new IllegalArgumentException("value must not be negative");
+    }
+  }
+
+  public String describe() {
+    return name + "=" + value;
+  }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/exampleTypes/RecordB.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/exampleTypes/RecordB.java
@@ -1,0 +1,14 @@
+package org.alfasoftware.astra.exampleTypes;
+
+public record RecordB(int value, String name) {
+
+  public RecordB {
+    if (value < 0) {
+      throw new IllegalArgumentException("value must not be negative");
+    }
+  }
+
+  public String describe() {
+    return name + "=" + value;
+  }
+}


### PR DESCRIPTION
Teach the AST visitor, type reference refactor and type matcher about records, sealed/non-sealed types, permits clauses and instanceof pattern bindings.

- ClassVisitor: visit RecordDeclaration (routed through abstract type declarations so records reach every operation) and PatternInstanceofExpression, with matching accessors.
- TypeReferenceRefactor: rewrite Javadoc type references on any AbstractTypeDeclaration (records/enums), and rename ordinary, canonical and record compact constructor names when the declaring type is renamed.
- TypeMatcher: add asRecord(), isSealed(), isNonSealed() and permitting(...); matches() now accepts any AbstractTypeDeclaration.

Adds before/after and matcher tests covering each construct.