### PR TITLE
Add withAnnotation() to MethodMatcher

### DIFF
--- a/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/MethodMatcher.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/MethodMatcher.java
@@ -6,8 +6,11 @@ import static org.alfasoftware.astra.core.utils.AstraUtils.getName;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -15,8 +18,10 @@ import org.alfasoftware.astra.core.utils.AstraUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Annotation;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IAnnotationBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
@@ -40,6 +45,7 @@ public class MethodMatcher {
   private Optional<MethodMatcher> parentContextMatcher = Optional.empty();
   private Optional<DescribedPredicate<String>> returnTypePredicate = Optional.empty();
   private Optional<DescribedPredicate<? super ASTNode>> customPredicate = Optional.empty();
+  private List<String> requiredAnnotations = new ArrayList<>();
 
 
   private MethodMatcher(Builder builder) {
@@ -52,6 +58,7 @@ public class MethodMatcher {
     this.parentContextMatcher = builder.parentContext;
     this.returnTypePredicate = builder.returnTypePredicate; // only implemented for MethodDeclarations so far
     this.customPredicate = builder.customPredicate;
+    this.requiredAnnotations = new ArrayList<>(builder.requiredAnnotations);
   }
 
   /**
@@ -75,6 +82,7 @@ public class MethodMatcher {
     private Optional<MethodMatcher> parentContext = Optional.empty();
     private Optional<DescribedPredicate<String>> returnTypePredicate = Optional.empty();
     private Optional<DescribedPredicate<? super ASTNode>> customPredicate = Optional.empty();
+    private List<String> requiredAnnotations = new ArrayList<>();
 
 
     /**
@@ -131,6 +139,21 @@ public class MethodMatcher {
       return this;
     }
 
+    /**
+     * Specifies a fully qualified annotation name that the method must be annotated with.
+     * Can be called multiple times; all supplied annotations must be present (AND semantics).
+     * Works for method declarations and also for invocation sites (by resolving the binding
+     * to the declaring method's annotations), making it possible to find all calls to
+     * methods carrying a given annotation — e.g. {@code withAnnotation("java.lang.Deprecated")}.
+     *
+     * @param fullyQualifiedAnnotationName the fully qualified name of the required annotation
+     * @return the builder
+     */
+    public Builder withAnnotation(String fullyQualifiedAnnotationName) {
+      this.requiredAnnotations.add(fullyQualifiedAnnotationName.replaceAll("\\$", "."));
+      return this;
+    }
+
     public MethodMatcher build() {
       return new MethodMatcher(this);
     }
@@ -184,6 +207,50 @@ public class MethodMatcher {
       .build();
   }
   
+
+  /**
+   * Checks that all required annotations are present among the provided binding annotations.
+   * Returns {@code true} if no annotations were specified.
+   */
+  private boolean isAnnotationMatch(IAnnotationBinding[] annotations) {
+    if (requiredAnnotations.isEmpty()) {
+      return true;
+    }
+    Set<String> presentAnnotations = Arrays.stream(annotations)
+        .map(IAnnotationBinding::getAnnotationType)
+        .filter(Objects::nonNull)
+        .map(ITypeBinding::getQualifiedName)
+        .collect(Collectors.toSet());
+    return presentAnnotations.containsAll(requiredAnnotations);
+  }
+
+
+  /**
+   * AST-level annotation check for {@link MethodDeclaration} nodes, used as a fallback
+   * when no binding is available. Matches against resolved annotation type names where
+   * possible, or against the unresolved annotation name as a last resort.
+   */
+  private boolean isAnnotationMatchFromAST(MethodDeclaration methodDeclaration) {
+    if (requiredAnnotations.isEmpty()) {
+      return true;
+    }
+    @SuppressWarnings("unchecked")
+    List<Object> modifiers = methodDeclaration.modifiers();
+    Set<String> presentNames = new HashSet<>();
+    for (Object modifier : modifiers) {
+      if (modifier instanceof Annotation) {
+        Annotation ann = (Annotation) modifier;
+        ITypeBinding typeBinding = ann.getTypeName().resolveTypeBinding();
+        if (typeBinding != null) {
+          presentNames.add(typeBinding.getQualifiedName());
+        } else {
+          presentNames.add(ann.getTypeName().getFullyQualifiedName());
+        }
+      }
+    }
+    return presentNames.containsAll(requiredAnnotations);
+  }
+
 
   private boolean isMethodNameMatch(MethodInvocation mi) {
     return ! methodNamePredicate.isPresent() || methodNamePredicate.get().test(mi.getName().toString());
@@ -351,7 +418,7 @@ public class MethodMatcher {
       return false;
     }
 
-    if (fullyQualifiedParameterNames.isPresent() || isVarargs.isPresent()) {
+    if (fullyQualifiedParameterNames.isPresent() || isVarargs.isPresent() || ! requiredAnnotations.isEmpty()) {
       final Optional<IMethodBinding> binding = Optional.of(methodInvocation)
           .map(MethodInvocation::resolveMethodBinding);
 
@@ -363,6 +430,7 @@ public class MethodMatcher {
       if (! binding
           .filter(mb -> ! isVarargs.isPresent() || isMethodVarargs(mb))
           .filter(this::isMethodParameterListMatch)
+          .filter(mb -> isAnnotationMatch(mb.getAnnotations()))
           .isPresent()) {
         return false;
       }
@@ -382,9 +450,12 @@ public class MethodMatcher {
       // do the parameters match?
         .filter(cic -> isMethodParameterListMatch(cic.resolveConstructorBinding()))
       // if we're checking whether it's varargs, does it match our expectation?
-        .filter(cic -> 
+        .filter(cic ->
           ! isVarargs.isPresent() || isMethodVarargs(cic.resolveConstructorBinding())
         )
+      // do the required annotations match?
+        .filter(cic -> cic.resolveConstructorBinding() != null &&
+            isAnnotationMatch(cic.resolveConstructorBinding().getAnnotations()))
       // does the classInstanceCreation match the custom predicate
         .filter(cic -> !customPredicate.isPresent() || customPredicate.get().test(cic))
         .isPresent();
@@ -403,6 +474,8 @@ public class MethodMatcher {
         .filter(imb ->
           ! isVarargs.isPresent() || isMethodVarargs(imb)
         )
+        // do the required annotations match?
+        .filter(imb -> isAnnotationMatch(imb.getAnnotations()))
         .isPresent();
   }
 
@@ -427,7 +500,16 @@ public class MethodMatcher {
     if (customPredicate.isPresent() && ! customPredicate.get().test(methodDeclaration)) {
       return false;
     }
-    
+
+    // Annotation check: prefer binding-based resolution; fall back to AST modifiers
+    if (binding.isPresent()) {
+      if (! isAnnotationMatch(binding.get().getAnnotations())) {
+        return false;
+      }
+    } else if (! isAnnotationMatchFromAST(methodDeclaration)) {
+      return false;
+    }
+
     return binding
         // is that method declared on the type we're looking for?
         .filter(this::isFQDeclaringTypeNameMatch)
@@ -474,6 +556,7 @@ public class MethodMatcher {
         ", fullyQualifiedParameterNames=" + fullyQualifiedParameterNames +
         ", varArgs=" + isVarargs +
         ", parentContext=" + parentContextMatcher +
+        ", requiredAnnotations=" + requiredAnnotations +
         "]";
   }
 

--- a/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/MethodMatcher.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/MethodMatcher.java
@@ -45,7 +45,7 @@ public class MethodMatcher {
   private Optional<MethodMatcher> parentContextMatcher = Optional.empty();
   private Optional<DescribedPredicate<String>> returnTypePredicate = Optional.empty();
   private Optional<DescribedPredicate<? super ASTNode>> customPredicate = Optional.empty();
-  private List<String> requiredAnnotations = new ArrayList<>();
+  private Optional<List<String>> requiredAnnotations = Optional.empty();
 
 
   private MethodMatcher(Builder builder) {
@@ -58,7 +58,7 @@ public class MethodMatcher {
     this.parentContextMatcher = builder.parentContext;
     this.returnTypePredicate = builder.returnTypePredicate; // only implemented for MethodDeclarations so far
     this.customPredicate = builder.customPredicate;
-    this.requiredAnnotations = new ArrayList<>(builder.requiredAnnotations);
+    this.requiredAnnotations = builder.requiredAnnotations;
   }
 
   /**
@@ -82,7 +82,7 @@ public class MethodMatcher {
     private Optional<MethodMatcher> parentContext = Optional.empty();
     private Optional<DescribedPredicate<String>> returnTypePredicate = Optional.empty();
     private Optional<DescribedPredicate<? super ASTNode>> customPredicate = Optional.empty();
-    private List<String> requiredAnnotations = new ArrayList<>();
+    private Optional<List<String>> requiredAnnotations = Optional.empty();
 
 
     /**
@@ -150,7 +150,11 @@ public class MethodMatcher {
      * @return the builder
      */
     public Builder withAnnotation(String fullyQualifiedAnnotationName) {
-      this.requiredAnnotations.add(fullyQualifiedAnnotationName.replaceAll("\\$", "."));
+    	  if (this.requiredAnnotations.isEmpty()) {
+    	    this.requiredAnnotations = Optional.of(new ArrayList<>());
+    	  }
+    	
+      this.requiredAnnotations.get().add(fullyQualifiedAnnotationName.replaceAll("\\$", "."));
       return this;
     }
 
@@ -213,7 +217,7 @@ public class MethodMatcher {
    * Returns {@code true} if no annotations were specified.
    */
   private boolean isAnnotationMatch(IAnnotationBinding[] annotations) {
-    if (requiredAnnotations.isEmpty()) {
+    if (requiredAnnotations.isEmpty() || requiredAnnotations.get().isEmpty()) {
       return true;
     }
     Set<String> presentAnnotations = Arrays.stream(annotations)
@@ -221,7 +225,7 @@ public class MethodMatcher {
         .filter(Objects::nonNull)
         .map(ITypeBinding::getQualifiedName)
         .collect(Collectors.toSet());
-    return presentAnnotations.containsAll(requiredAnnotations);
+    return presentAnnotations.containsAll(requiredAnnotations.get());
   }
 
 
@@ -231,15 +235,14 @@ public class MethodMatcher {
    * possible, or against the unresolved annotation name as a last resort.
    */
   private boolean isAnnotationMatchFromAST(MethodDeclaration methodDeclaration) {
-    if (requiredAnnotations.isEmpty()) {
+    if (requiredAnnotations.isEmpty() || requiredAnnotations.get().isEmpty()) {
       return true;
     }
     @SuppressWarnings("unchecked")
     List<Object> modifiers = methodDeclaration.modifiers();
     Set<String> presentNames = new HashSet<>();
     for (Object modifier : modifiers) {
-      if (modifier instanceof Annotation) {
-        Annotation ann = (Annotation) modifier;
+      if (modifier instanceof Annotation ann) {
         ITypeBinding typeBinding = ann.getTypeName().resolveTypeBinding();
         if (typeBinding != null) {
           presentNames.add(typeBinding.getQualifiedName());
@@ -248,7 +251,7 @@ public class MethodMatcher {
         }
       }
     }
-    return presentNames.containsAll(requiredAnnotations);
+    return presentNames.containsAll(requiredAnnotations.get());
   }
 
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/ExampleClassCallingAnnotatedMethod.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/ExampleClassCallingAnnotatedMethod.java
@@ -1,0 +1,12 @@
+package org.alfasoftware.astra.core.matchers;
+
+class ExampleClassCallingAnnotatedMethod {
+
+  @SuppressWarnings("deprecation")
+  void callMethods() {
+    ExampleUsedClassWithAnnotatedMethods obj = new ExampleUsedClassWithAnnotatedMethods();
+    obj.deprecatedMethod();
+    obj.suppressedMethod();
+    obj.normalMethod();
+  }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/ExampleUsedClassWithAnnotatedMethods.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/ExampleUsedClassWithAnnotatedMethods.java
@@ -1,0 +1,12 @@
+package org.alfasoftware.astra.core.matchers;
+
+class ExampleUsedClassWithAnnotatedMethods {
+
+  @Deprecated
+  void deprecatedMethod() {}
+
+  @SuppressWarnings("unused")
+  void suppressedMethod() {}
+
+  void normalMethod() {}
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestMethodMatcher.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestMethodMatcher.java
@@ -277,7 +277,7 @@ public class TestMethodMatcher {
         + "fullyQualifiedParameterNames=Optional.empty, "
         + "varArgs=Optional.empty, "
         + "parentContext=Optional.empty, "
-        + "requiredAnnotations=[]]",
+        + "requiredAnnotations=Optional.empty]",
         matcherWithDefaultPredicateDescriptions.toString());
 
     assertEquals("MethodMatcher ["
@@ -286,7 +286,7 @@ public class TestMethodMatcher {
         + "fullyQualifiedParameterNames=Optional.empty, "
         + "varArgs=Optional.empty, "
         + "parentContext=Optional.empty, "
-        + "requiredAnnotations=[]]",
+        + "requiredAnnotations=Optional.empty]",
         matcherWithDescribedPredicates.toString());
   }
 

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestMethodMatcher.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestMethodMatcher.java
@@ -276,7 +276,8 @@ public class TestMethodMatcher {
         + "fullyQualifiedDeclaringType=Optional[FQ type is [com.Foo]], "
         + "fullyQualifiedParameterNames=Optional.empty, "
         + "varArgs=Optional.empty, "
-        + "parentContext=Optional.empty]",
+        + "parentContext=Optional.empty, "
+        + "requiredAnnotations=[]]",
         matcherWithDefaultPredicateDescriptions.toString());
 
     assertEquals("MethodMatcher ["
@@ -284,7 +285,8 @@ public class TestMethodMatcher {
         + "fullyQualifiedDeclaringType=Optional[" + customFQTypeDescription + "], "
         + "fullyQualifiedParameterNames=Optional.empty, "
         + "varArgs=Optional.empty, "
-        + "parentContext=Optional.empty]",
+        + "parentContext=Optional.empty, "
+        + "requiredAnnotations=[]]",
         matcherWithDescribedPredicates.toString());
   }
 
@@ -427,6 +429,94 @@ public class TestMethodMatcher {
     checkNoMethodMatchFoundInClass(methodInvocationMatcher, ExampleClassUsingMethodWithClassParameter.class);
     checkMethodMatchFoundInClass(classInstanceCreationMatcher, ExampleClassUsingMultipleMethods.class);
     checkNoMethodMatchFoundInClass(classInstanceCreationMatcherNoMatch, ExampleClassUsingMultipleMethods.class);
+  }
+
+
+  /**
+   * Tests that a method declaration annotated with {@code @Deprecated} is matched
+   * when the matcher specifies that annotation.
+   */
+  @Test
+  public void testMatchMethodDeclarationByAnnotation() {
+    MethodMatcher deprecatedMatcher = MethodMatcher.builder()
+        .withAnnotation("java.lang.Deprecated")
+        .build();
+
+    checkMethodMatchFoundInClass(deprecatedMatcher, ExampleUsedClassWithAnnotatedMethods.class);
+  }
+
+
+  /**
+   * Tests that a non-annotated method declaration is NOT matched when the matcher
+   * requires a specific annotation that is absent.
+   */
+  @Test
+  public void testNoMatchMethodDeclarationByAnnotationWhenNotAnnotated() {
+    MethodMatcher deprecatedMatcher = MethodMatcher.builder()
+        .withMethodName("normalMethod")
+        .withAnnotation("java.lang.Deprecated")
+        .build();
+
+    checkNoMethodMatchFoundInClass(deprecatedMatcher, ExampleUsedClassWithAnnotatedMethods.class);
+  }
+
+
+  /**
+   * Tests that combining annotation + method-name constraints narrows the match correctly:
+   * only the deprecated method matches, not the suppressed or normal ones.
+   */
+  @Test
+  public void testMatchMethodDeclarationByAnnotationAndName() {
+    MethodMatcher deprecatedMethodMatcher = MethodMatcher.builder()
+        .withMethodName("deprecatedMethod")
+        .withAnnotation("java.lang.Deprecated")
+        .build();
+
+    MethodMatcher suppressedMethodMatcher = MethodMatcher.builder()
+        .withMethodName("suppressedMethod")
+        .withAnnotation("java.lang.Deprecated")
+        .build();
+
+    checkMethodMatchFoundInClass(deprecatedMethodMatcher, ExampleUsedClassWithAnnotatedMethods.class);
+    checkNoMethodMatchFoundInClass(suppressedMethodMatcher, ExampleUsedClassWithAnnotatedMethods.class);
+  }
+
+
+  /**
+   * Tests that method invocations of a {@code @Deprecated} method are matched at the
+   * call site by resolving the binding to the declaration's annotations.
+   */
+  @Test
+  public void testMatchMethodInvocationByAnnotation() {
+    MethodMatcher deprecatedInvocationMatcher = MethodMatcher.builder()
+        .withFullyQualifiedDeclaringType(ExampleUsedClassWithAnnotatedMethods.class.getName())
+        .withAnnotation("java.lang.Deprecated")
+        .build();
+
+    MethodMatcher suppressedInvocationMatcher = MethodMatcher.builder()
+        .withFullyQualifiedDeclaringType(ExampleUsedClassWithAnnotatedMethods.class.getName())
+        .withMethodName("suppressedMethod")
+        .withAnnotation("java.lang.Deprecated")
+        .build();
+
+    checkMethodMatchFoundInClass(deprecatedInvocationMatcher, ExampleClassCallingAnnotatedMethod.class);
+    checkNoMethodMatchFoundInClass(suppressedInvocationMatcher, ExampleClassCallingAnnotatedMethod.class);
+  }
+
+
+  /**
+   * Tests that a call to a non-annotated method is NOT matched when the matcher
+   * requires a specific annotation.
+   */
+  @Test
+  public void testNoMatchMethodInvocationByAnnotationWhenNotAnnotated() {
+    MethodMatcher deprecatedNormalMethodMatcher = MethodMatcher.builder()
+        .withFullyQualifiedDeclaringType(ExampleUsedClassWithAnnotatedMethods.class.getName())
+        .withMethodName("normalMethod")
+        .withAnnotation("java.lang.Deprecated")
+        .build();
+
+    checkNoMethodMatchFoundInClass(deprecatedNormalMethodMatcher, ExampleClassCallingAnnotatedMethod.class);
   }
 
 


### PR DESCRIPTION
Allows matching methods by the annotations they carry, covering both declaration and invocation sites:

- MethodMatcher.Builder.withAnnotation(String fullyQualifiedName) — chainable; all specified annotations must be present (AND semantics). Inner-class $ notation is normalised to dots, consistent with other FQ-name fields on the builder.
- For MethodDeclaration: resolves annotations via IMethodBinding where available; falls back to AST-modifier inspection when the binding is absent.
- For MethodInvocation: resolves the binding to the declaring method and checks its annotation bindings, so call sites of @Deprecated (or any other annotated) methods are matched without needing the annotation at the call site.
- For ClassInstanceCreation / IMethodBinding: checks via the resolved constructor / method binding in the same way.

toString() updated to include requiredAnnotations (existing logging test updated accordingly).

Adds example types ExampleUsedClassWithAnnotatedMethods / ExampleClassCallingAnnotatedMethod and five new @Test methods in TestMethodMatcher (declaration positive/negative, declaration with name constraint, invocation positive/negative).