### PR TITLE
Implement return-type matching for method invocations in MethodMatcher

### DIFF
--- a/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/MethodMatcher.java
+++ b/astra-core/src/main/java/org/alfasoftware/astra/core/matchers/MethodMatcher.java
@@ -26,6 +26,13 @@ import org.eclipse.jdt.core.dom.MethodInvocation;
  * A way of matching a method by its properties.
  * Examples of method properties that can be used to match include the method name,
  * arguments, the fully qualified name of the declaring type, and the return type.
+ *
+ * <p>Return-type matching is supported across all of the matched node kinds -
+ * {@link MethodInvocation}, {@link ClassInstanceCreation}, {@link MethodDeclaration}
+ * and {@link IMethodBinding}. For the binding-based node kinds this requires the
+ * method binding to be resolvable (i.e. the appropriate sources / classpaths must be
+ * supplied); where it cannot be resolved a warning is logged and the matcher reports
+ * a non-match, in line with the handling of other binding-based criteria.</p>
  */
 public class MethodMatcher {
 
@@ -50,7 +57,7 @@ public class MethodMatcher {
     this.fullyQualifiedParameterNames = builder.fullyQualifiedParameterNames;
     this.isVarargs = builder.isVarargs;
     this.parentContextMatcher = builder.parentContext;
-    this.returnTypePredicate = builder.returnTypePredicate; // only implemented for MethodDeclarations so far
+    this.returnTypePredicate = builder.returnTypePredicate;
     this.customPredicate = builder.customPredicate;
   }
 
@@ -123,7 +130,9 @@ public class MethodMatcher {
       return this;
     }
     public Builder withfullyQualifiedReturnType(String fullyQualifiedReturnType) {
-      this.returnTypePredicate = Optional.of(describedPredicate("method return type is [" + fullyQualifiedReturnType + "]", Predicate.isEqual(fullyQualifiedReturnType)));
+      // Removing $ from inner class names as this won't match with resolved type binding names
+      String exactName = fullyQualifiedReturnType.replaceAll("\\$", ".");
+      this.returnTypePredicate = Optional.of(describedPredicate("method return type is [" + fullyQualifiedReturnType + "]", Predicate.isEqual(exactName)));
       return this;
     }
     public Builder withCustomPredicate(DescribedPredicate<? super ASTNode> customInvocationPredicate) {
@@ -284,6 +293,41 @@ public class MethodMatcher {
       .isPresent();
   }
 
+
+  /**
+   * @return true if we aren't matching on return type, or if the supplied fully qualified
+   *         return type satisfies the configured return type predicate.
+   */
+  private boolean returnTypeMatches(String fullyQualifiedReturnType) {
+    if (! returnTypePredicate.isPresent()) {
+      return true;
+    }
+    if (fullyQualifiedReturnType == null) {
+      return false;
+    }
+    // Normalise inner class names so that nested return types match, in line with the
+    // handling of declaring types and parameter types elsewhere in this matcher.
+    return returnTypePredicate.get().test(fullyQualifiedReturnType.replaceAll("\\$", "."));
+  }
+
+
+  /**
+   * @return true if we aren't matching on return type, or if the return type of the supplied
+   *         method binding satisfies the configured return type predicate. The comparison is
+   *         performed against the fully qualified name (erasure for generics) so that behaviour
+   *         is consistent with the {@link MethodDeclaration} return type matching.
+   */
+  private boolean returnTypeMatches(IMethodBinding methodBinding) {
+    if (! returnTypePredicate.isPresent()) {
+      return true;
+    }
+    final ITypeBinding returnTypeBinding = methodBinding.getReturnType();
+    if (returnTypeBinding == null) {
+      return false;
+    }
+    return returnTypeMatches(getName(returnTypeBinding));
+  }
+
   
   private boolean isSimpleNameMatch(ClassInstanceCreation cic) {
     return ! methodNamePredicate.isPresent() || methodNamePredicate.get().test(AstraUtils.getSimpleName(cic.getType().toString()));
@@ -351,7 +395,7 @@ public class MethodMatcher {
       return false;
     }
 
-    if (fullyQualifiedParameterNames.isPresent() || isVarargs.isPresent()) {
+    if (fullyQualifiedParameterNames.isPresent() || isVarargs.isPresent() || returnTypePredicate.isPresent()) {
       final Optional<IMethodBinding> binding = Optional.of(methodInvocation)
           .map(MethodInvocation::resolveMethodBinding);
 
@@ -363,6 +407,7 @@ public class MethodMatcher {
       if (! binding
           .filter(mb -> ! isVarargs.isPresent() || isMethodVarargs(mb))
           .filter(this::isMethodParameterListMatch)
+          .filter(this::returnTypeMatches)
           .isPresent()) {
         return false;
       }
@@ -382,9 +427,11 @@ public class MethodMatcher {
       // do the parameters match?
         .filter(cic -> isMethodParameterListMatch(cic.resolveConstructorBinding()))
       // if we're checking whether it's varargs, does it match our expectation?
-        .filter(cic -> 
+        .filter(cic ->
           ! isVarargs.isPresent() || isMethodVarargs(cic.resolveConstructorBinding())
         )
+      // does the return type match? (constructor bindings report a void return type in JDT)
+        .filter(cic -> returnTypeMatches(cic.resolveConstructorBinding()))
       // does the classInstanceCreation match the custom predicate
         .filter(cic -> !customPredicate.isPresent() || customPredicate.get().test(cic))
         .isPresent();
@@ -403,6 +450,8 @@ public class MethodMatcher {
         .filter(imb ->
           ! isVarargs.isPresent() || isMethodVarargs(imb)
         )
+        // does the return type match?
+        .filter(this::returnTypeMatches)
         .isPresent();
   }
 
@@ -412,7 +461,7 @@ public class MethodMatcher {
       // does the method name match?
       .filter(m -> !methodNamePredicate.isPresent() || methodNamePredicate.get().test(m.getName().toString()))
       // does the return type match?
-      .filter(m -> !returnTypePredicate.isPresent() || returnTypePredicate.get().test(AstraUtils.getFullyQualifiedName(m.getReturnType2())));
+      .filter(m -> returnTypeMatches(AstraUtils.getFullyQualifiedName(m.getReturnType2())));
 
     final Optional<IMethodBinding> binding = method
       // Now on to the things that require a resolved binding

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/ExampleClassUsingConstructorWithVoidReturnType.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/ExampleClassUsingConstructorWithVoidReturnType.java
@@ -1,0 +1,9 @@
+package org.alfasoftware.astra.core.matchers;
+
+class ExampleClassUsingConstructorWithVoidReturnType {
+
+  void exampleMethod() {
+    ExampleUsedClass usedClass = new ExampleUsedClass();
+    System.out.println(usedClass);
+  }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/ExampleClassUsingInvocationWithReturnTypeInt.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/ExampleClassUsingInvocationWithReturnTypeInt.java
@@ -1,0 +1,10 @@
+package org.alfasoftware.astra.core.matchers;
+
+class ExampleClassUsingInvocationWithReturnTypeInt {
+
+  void exampleMethod() {
+    String value = "example";
+    int length = value.length();
+    System.out.println(length);
+  }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/ExampleClassUsingInvocationWithReturnTypeString.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/ExampleClassUsingInvocationWithReturnTypeString.java
@@ -1,0 +1,10 @@
+package org.alfasoftware.astra.core.matchers;
+
+class ExampleClassUsingInvocationWithReturnTypeString {
+
+  void exampleMethod() {
+    ExampleUsedClass usedClass = new ExampleUsedClass();
+    String result = usedClass.baseMethod();
+    System.out.println(result);
+  }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/ExampleClassUsingInvocationWithReturnTypeVoid.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/ExampleClassUsingInvocationWithReturnTypeVoid.java
@@ -1,0 +1,9 @@
+package org.alfasoftware.astra.core.matchers;
+
+class ExampleClassUsingInvocationWithReturnTypeVoid {
+
+  void exampleMethod() {
+    StringBuilder builder = new StringBuilder();
+    builder.trimToSize();
+  }
+}

--- a/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestMethodMatcherReturnTypeForInvocations.java
+++ b/astra-core/src/test/java/org/alfasoftware/astra/core/matchers/TestMethodMatcherReturnTypeForInvocations.java
@@ -1,0 +1,188 @@
+package org.alfasoftware.astra.core.matchers;
+
+import static org.alfasoftware.astra.core.matchers.DescribedPredicate.describedPredicate;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.alfasoftware.astra.core.utils.AstraUtils;
+import org.alfasoftware.astra.core.utils.ClassVisitor;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.junit.Test;
+
+/**
+ * Tests that the {@link MethodMatcher} can match by return type for method invocations
+ * (and constructors), not just method declarations.
+ *
+ * <p>Return-type matching on invocations and constructors requires the method binding to be
+ * resolvable, so these tests supply the test sources on the classpath in the same way as the
+ * existing binding-dependent {@link TestMethodMatcher} tests.</p>
+ */
+public class TestMethodMatcherReturnTypeForInvocations {
+
+  private static final String TEST_SOURCE = Paths.get(".").toAbsolutePath().normalize().toString().concat("/src/test/java");
+  private static final String TEST_EXAMPLES = "./src/test/java";
+
+
+  /**
+   * A method invocation should match when its resolved return type is the configured one.
+   */
+  @Test
+  public void testInvocationMatchesWhenReturnTypeMatches() {
+    MethodMatcher returnsStringMatcher = MethodMatcher.builder()
+        .withMethodName("baseMethod")
+        .withReturnType(describedPredicate("Return type should be String", s -> s.equals(String.class.getName())))
+        .build();
+
+    checkMethodMatchFoundInClass(returnsStringMatcher, ExampleClassUsingInvocationWithReturnTypeString.class);
+  }
+
+
+  /**
+   * The exact-string return type form should work for invocations too.
+   */
+  @Test
+  public void testInvocationMatchesWhenReturnTypeMatchesExactString() {
+    MethodMatcher returnsStringMatcher = MethodMatcher.builder()
+        .withMethodName("baseMethod")
+        .withfullyQualifiedReturnType(String.class.getName())
+        .build();
+
+    checkMethodMatchFoundInClass(returnsStringMatcher, ExampleClassUsingInvocationWithReturnTypeString.class);
+  }
+
+
+  /**
+   * A method invocation should not match when its resolved return type differs from the configured one.
+   */
+  @Test
+  public void testInvocationDoesNotMatchWhenReturnTypeDiffers() {
+    MethodMatcher returnsStringMatcher = MethodMatcher.builder()
+        .withMethodName("length")
+        .withReturnType(describedPredicate("Return type should be String", s -> s.equals(String.class.getName())))
+        .build();
+
+    // length() returns int, so the String return-type matcher must not match it.
+    checkNoMethodMatchFoundInClass(returnsStringMatcher, ExampleClassUsingInvocationWithReturnTypeInt.class);
+  }
+
+
+  /**
+   * A void-returning invocation should match a matcher configured with a void return type.
+   */
+  @Test
+  public void testVoidInvocationMatchesVoidReturnType() {
+    MethodMatcher returnsVoidMatcher = MethodMatcher.builder()
+        .withMethodName("trimToSize")
+        .withReturnType(describedPredicate("Return type should be void", s -> s.equals("void")))
+        .build();
+
+    checkMethodMatchFoundInClass(returnsVoidMatcher, ExampleClassUsingInvocationWithReturnTypeVoid.class);
+  }
+
+
+  /**
+   * A void-returning invocation should not match a non-void return type matcher.
+   */
+  @Test
+  public void testVoidInvocationDoesNotMatchStringReturnType() {
+    MethodMatcher returnsStringMatcher = MethodMatcher.builder()
+        .withMethodName("trimToSize")
+        .withReturnType(describedPredicate("Return type should be String", s -> s.equals(String.class.getName())))
+        .build();
+
+    checkNoMethodMatchFoundInClass(returnsStringMatcher, ExampleClassUsingInvocationWithReturnTypeVoid.class);
+  }
+
+
+  /**
+   * A constructor (class instance creation) reports a void return type in JDT,
+   * so it should match a void return-type matcher.
+   */
+  @Test
+  public void testConstructorMatchesVoidReturnType() {
+    MethodMatcher constructorMatcher = MethodMatcher.builder()
+        .withMethodName("ExampleUsedClass")
+        .withReturnType(describedPredicate("Return type should be void", s -> s.equals("void")))
+        .build();
+
+    checkMethodMatchFoundInClass(constructorMatcher, ExampleClassUsingConstructorWithVoidReturnType.class);
+  }
+
+
+  /**
+   * Regression test: return-type matching on method declarations must still work.
+   */
+  @Test
+  public void testMethodDeclarationReturnTypeStillMatches() {
+    MethodMatcher returnsStringMatcher = MethodMatcher.builder()
+        .withReturnType(describedPredicate("Return type should be String", s -> s.equals(String.class.getName())))
+        .build();
+
+    checkMethodMatchFoundInClass(returnsStringMatcher, ExampleClassUsingMethodWithReturnTypeString.class);
+    checkNoMethodMatchFoundInClass(returnsStringMatcher, ExampleClassUsingMethodWithReturnTypeInt.class);
+  }
+
+
+  private void checkMethodMatchFoundInClass(MethodMatcher methodMatcherToTest, Class<?> clazzToTest) {
+    checkMethodMatchInClass(methodMatcherToTest, clazzToTest, true);
+  }
+
+  private void checkNoMethodMatchFoundInClass(MethodMatcher methodMatcherToTest, Class<?> clazzToTest) {
+    checkMethodMatchInClass(methodMatcherToTest, clazzToTest, false);
+  }
+
+
+  private void checkMethodMatchInClass(MethodMatcher methodMatcherToTest, Class<?> clazzToTest, boolean shouldFindMatch) {
+    File fileToTest = new File(TEST_EXAMPLES + "/" + clazzToTest.getName().replaceAll("\\.", "/") + ".java");
+    String fileContentBefore = null;
+    try {
+      fileContentBefore = new String(Files.readAllBytes(fileToTest.toPath()));
+    } catch (IOException e) {
+      fail("IOException when reading file : " + e);
+    }
+
+    CompilationUnit compilationUnit = AstraUtils.readAsCompilationUnit(Path.of(""), fileContentBefore, new String[]{TEST_SOURCE}, new String[0]);
+
+    final ClassVisitor visitor = new ClassVisitor();
+    compilationUnit.accept(visitor);
+
+    for (MethodInvocation methodInvocation : visitor.getMethodInvocations()) {
+      if (methodMatcherToTest.matches(methodInvocation, compilationUnit)) {
+        if (shouldFindMatch) {
+          return;
+        } else {
+          fail("Should be no matches in class [" + clazzToTest.getName() + "] but found one at [" + methodInvocation.toString() + "]");
+        }
+      }
+    }
+    for (MethodDeclaration methodDeclaration : visitor.getMethodDeclarations()) {
+      if (methodMatcherToTest.matches(methodDeclaration)) {
+        if (shouldFindMatch) {
+          return;
+        } else {
+          fail("Should be no matches in class [" + clazzToTest.getName() + "] but found one at [" + methodDeclaration.toString() + "]");
+        }
+      }
+    }
+    for (ClassInstanceCreation classInstanceCreation : visitor.getClassInstanceCreations()) {
+      if (methodMatcherToTest.matches(classInstanceCreation)) {
+        if (shouldFindMatch) {
+          return;
+        } else {
+          fail("Should be no matches in class [" + clazzToTest.getName() + "] but found one at [" + classInstanceCreation.toString() + "]");
+        }
+      }
+    }
+    if (shouldFindMatch) {
+      fail("Should have found a match for [" + methodMatcherToTest + "] within [" + fileContentBefore + "]");
+    }
+  }
+}


### PR DESCRIPTION
Return-type matching previously only worked for MethodDeclaration nodes and was silently ignored for MethodInvocation, ClassInstanceCreation and the IMethodBinding overload. This resolves the method binding and compares the fully qualified return type (erasure for generics, void handled), sharing the comparison logic across all node kinds, with inner-class ($ -> .) normalisation and warn + non-match handling for unresolved bindings.